### PR TITLE
Always update peer_tag, not only from a response

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -2947,6 +2947,21 @@ bool call::process_incoming(char * msg, struct sockaddr_storage *src)
   }
 #endif
 
+    /* It is a response: update peer_tag */
+    ptr = get_peer_tag(msg);
+    if (ptr) {
+        if(strlen(ptr) > (MAX_HEADER_LEN - 1)) {
+            ERROR("Peer tag too long. Change MAX_HEADER_LEN and recompile sipp");
+        }
+        if(peer_tag) {
+            free(peer_tag);
+        }
+        peer_tag = strdup(ptr);
+        if (!peer_tag) {
+            ERROR("Out of memory allocating peer tag.");
+        }
+    }
+
     /* Is it a response ? */
     if((msg[0] == 'S') &&
             (msg[1] == 'I') &&
@@ -2966,20 +2981,6 @@ bool call::process_incoming(char * msg, struct sockaddr_storage *src)
             /* Get media info if we find something like an SDP */
             get_remote_media_addr(msg);
 #endif
-        }
-        /* It is a response: update peer_tag */
-        ptr = get_peer_tag(msg);
-        if (ptr) {
-            if(strlen(ptr) > (MAX_HEADER_LEN - 1)) {
-                ERROR("Peer tag too long. Change MAX_HEADER_LEN and recompile sipp");
-            }
-            if(peer_tag) {
-                free(peer_tag);
-            }
-            peer_tag = strdup(ptr);
-            if (!peer_tag) {
-                ERROR("Out of memory allocating peer tag.");
-            }
         }
         request[0]=0;
         // extract the cseq method from the response


### PR DESCRIPTION
A UAC scenario might receive only an INVITE, and then need to send a BYE immediately. Without parsing the peer_tag from the INVITE, this will never succeed.
