### PR TITLE
Extract media info only if a rtp_stream exec action is used.

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -2942,7 +2942,8 @@ bool call::process_incoming(char * msg, struct sockaddr_storage *src)
 
 #ifdef RTP_STREAM
   /* Check if message has a SDP in it; and extract media information. */
-  if (!strcmp(get_header_content(msg, (char*)"Content-Type:"),"application/sdp")) {
+  if (!strcmp(get_header_content(msg, (char*)"Content-Type:"),"application/sdp") &&
+          (hasMedia == 1)) {
     extract_rtp_remote_addr(msg);
   }
 #endif

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -1624,6 +1624,7 @@ void scenario::parseAction(CActions *actions)
 #endif
       } else if ((ptr = xp_get_value((char *) "rtp_stream"))) {
 #ifdef RTP_STREAM
+        hasMedia = 1;
 	if (!strcmp(ptr, "pause")) {
          tmpAction->setActionType(CAction::E_AT_RTP_STREAM_PAUSE);
 	} else if (!strcmp(ptr, "resume")) {


### PR DESCRIPTION
This patch makes the rtp streaming feature behave like the pcap play feature in
that it will extract the media info from the SDP only if a rtp_stream exec
action is used.
