### PR TITLE
updated get_bool to allow capitalized booleans

### DIFF
--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -439,10 +439,10 @@ bool get_bool(const char *ptr, const char *what)
     char *endptr;
     long ret;
 
-    if (!strcmp(ptr, "true")) {
+    if (!strcasecmp(ptr, "true")) {
         return true;
     }
-    if (!strcmp(ptr, "false")) {
+    if (!strcasecmp(ptr, "false")) {
         return false;
     }
 


### PR DESCRIPTION
This is just a very small fix for Issue #15: https://github.com/SIPp/sipp/issues/15
