### PR TITLE
send_packets: Avoid crashing on errors in sendto call.

### DIFF
--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -238,9 +238,8 @@ int send_packets (play_args_t * play_args)
         }
 #endif
         if (ret < 0) {
-            close(sock);
             WARNING("send_packets.c: sendto failed with error: %s", strerror(errno));
-            return( -1);
+            break;
         }
 
         rtp_pckts_pcap++;
@@ -251,7 +250,7 @@ int send_packets (play_args_t * play_args)
 
     /* Closing the socket is handled by pthread_cleanup_push()/pthread_cleanup_pop() */
     pthread_cleanup_pop(1);
-    return 0;
+    return (ret < 0) ? ret : 0;
 }
 
 /*


### PR DESCRIPTION
If sendto() returned an error, pthread_cleanup_pop() was not called before
return, resulting in a segfault on my CentOS 5.x platform.

Next, I need to look into why sendto is failing on CentOS 5.x but not on other
platforms.
