### PR TITLE
Allow specifying the screen trace file

### DIFF
--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -73,6 +73,7 @@ void log_off(struct logfile_info *lfi);
 #endif
 LOGFILE(calldebug_lfi, "calldebug", true);
 LOGFILE(message_lfi, "messages", true);
+LOGFILE(screen_lfi, "screen", true);
 LOGFILE(shortmessage_lfi, "shortmessages", true);
 LOGFILE(log_lfi, "logs", true);
 LOGFILE(error_lfi, "errors", false);
@@ -81,6 +82,7 @@ void rotate_logfile();
 void rotate_shortmessagef();
 void rotate_errorf();
 void rotate_messagef();
+void rotate_screenf();
 void rotate_calldebugf();
 
 /* Screen/Statistics Printing Functions. */

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -828,25 +828,25 @@ void print_screens(void)
     int oldRepartition = currentRepartitionToDisplay;
 
     currentScreenToDisplay = DISPLAY_SCENARIO_SCREEN;
-    print_header_line(   screenf);
-    print_stats_in_file( screenf);
-    print_bottom_line(   screenf, NOTLAST);
+    print_header_line(   screen_lfi.fptr);
+    print_stats_in_file( screen_lfi.fptr);
+    print_bottom_line(   screen_lfi.fptr, NOTLAST);
 
     currentScreenToDisplay = DISPLAY_STAT_SCREEN;
-    print_header_line(   screenf);
-    display_scenario->stats->displayStat(screenf);
-    print_bottom_line(   screenf, NOTLAST);
+    print_header_line(   screen_lfi.fptr);
+    display_scenario->stats->displayStat(screen_lfi.fptr);
+    print_bottom_line(   screen_lfi.fptr, NOTLAST);
 
     currentScreenToDisplay = DISPLAY_REPARTITION_SCREEN;
-    print_header_line(   screenf);
-    display_scenario->stats->displayRepartition(screenf);
-    print_bottom_line(   screenf, NOTLAST);
+    print_header_line(   screen_lfi.fptr);
+    display_scenario->stats->displayRepartition(screen_lfi.fptr);
+    print_bottom_line(   screen_lfi.fptr, NOTLAST);
 
     currentScreenToDisplay = DISPLAY_SECONDARY_REPARTITION_SCREEN;
     for (currentRepartitionToDisplay = 2; currentRepartitionToDisplay <= display_scenario->stats->nRtds(); currentRepartitionToDisplay++) {
-        print_header_line(   screenf);
-        display_scenario->stats->displayRtdRepartition(screenf, currentRepartitionToDisplay);
-        print_bottom_line(   screenf, NOTLAST);
+        print_header_line(   screen_lfi.fptr);
+        display_scenario->stats->displayRtdRepartition(screen_lfi.fptr, currentRepartitionToDisplay);
+        print_bottom_line(   screen_lfi.fptr, NOTLAST);
     }
 
     currentScreenToDisplay = oldScreen;
@@ -907,6 +907,11 @@ void rotatef(struct logfile_info *lfi)
         /* We can not use the error functions from this function, as we may be rotating the error log itself! */
         ERROR("Unable to create '%s'", lfi->file_name);
     }
+}
+
+void rotate_screenf()
+{
+    rotatef(&screen_lfi);
 }
 
 void rotate_calldebugf()

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -356,6 +356,8 @@ struct sipp_option options_table[] = {
     {"calldebug_overwrite", "Overwrite the call debug file (default true).", SIPP_OPTION_LFOVERWRITE, &calldebug_lfi, 1},
 
     {"trace_screen", "Dump statistic screens in the <scenario_name>_<pid>_screens.log file when quitting SIPp. Useful to get a final status report in background mode (-bg option).", SIPP_OPTION_SETFLAG, &useScreenf, 1},
+    {"screen_file", "Set the name of the screen file.", SIPP_OPTION_LFNAME, &screen_lfi, 1},
+    {"screen_overwrite", "Overwrite the screen file (default true).", SIPP_OPTION_LFOVERWRITE, &screen_lfi, 1},
 
     {"trace_rtt", "Allow tracing of all response times in <scenario file name>_<pid>_rtt.csv.", SIPP_OPTION_SETFLAG, &dumpInRtt, 1},
     {"rtt_freq", "freq is mandatory. Dump response times every freq calls in the log file defined by -trace_rtt. Default value is 200.",
@@ -698,18 +700,13 @@ void traffic_thread()
 
         if (signalDump) {
             /* Screen dumping in a file */
-            if (screenf) {
+            if (useScreenf == 1) {
                 print_screens();
             } else {
                 /* If the -trace_screen option has not been set, */
                 /* create the file at this occasion              */
-                screenf = fopen(L_file_name, "a");
-                if (!screenf) {
-                    WARNING("Unable to create '%s'", L_file_name);
-                }
+                rotate_screenf();
                 print_screens();
-                fclose(screenf);
-                screenf = 0;
             }
 
             if(dumpInRtt) {
@@ -745,7 +742,7 @@ void traffic_thread()
 
                 screentask::report(true);
                 stattask::report();
-                if (screenf) {
+                if (useScreenf == 1) {
                     print_screens();
                 }
 
@@ -1802,12 +1799,7 @@ int main(int argc, char *argv[])
     }
 
     if (useScreenf == 1) {
-        char L_file_name [MAX_PATH];
-        sprintf (L_file_name, "%s_%d_screen.log", scenario_file, getpid());
-        screenf = fopen(L_file_name, "w");
-        if(!screenf) {
-            ERROR("Unable to create '%s'", L_file_name);
-        }
+        rotate_screenf();
     }
 
     // TODO: finish the -trace_timeout option implementation


### PR DESCRIPTION
Most of the log files allow specifying a specific file to write, but `-trace_screen` did not. This PR adds the ability to specify the screen trace output file.
