### PR TITLE
Separate call rate increase to a dedicated task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *~
+.*.sw*
 .deps/
 Makefile
 autom4te.cache/

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,7 @@ common_incl = include/comp.h \
 	        include/message.hpp \
 	        include/milenage.h \
 	        include/call_generation_task.hpp \
+	        include/ratetask.hpp \
 	        include/reporttask.hpp \
 	        include/rijndael.h \
 	        include/scenario.hpp \
@@ -82,6 +83,7 @@ common_SOURCES = src/actions.cpp \
 	       src/message.cpp \
 	       src/milenage.c \
 	       src/call_generation_task.cpp \
+	       src/ratetask.cpp \
 	       src/reporttask.cpp \
 	       src/rijndael.c \
 	       src/scenario.cpp \

--- a/Makefile.in
+++ b/Makefile.in
@@ -109,24 +109,25 @@ PROGRAMS = $(bin_PROGRAMS) $(noinst_PROGRAMS)
 am__sipp_SOURCES_DIST = src/actions.cpp src/auth.cpp src/comp.c \
 	src/call.cpp src/deadcall.cpp src/infile.cpp src/listener.cpp \
 	src/logger.cpp src/md5.c src/message.cpp src/milenage.c \
-	src/call_generation_task.cpp src/reporttask.cpp src/rijndael.c \
-	src/scenario.cpp src/sip_parser.cpp src/screen.cpp \
-	src/socket.cpp src/socketowner.cpp src/stat.cpp \
-	src/strings.cpp src/task.cpp src/time.cpp src/variables.cpp \
-	src/watchdog.cpp src/xp_parser.c include/comp.h \
-	include/infile.hpp include/listener.hpp include/logger.hpp \
-	include/md5.h include/message.hpp include/milenage.h \
-	include/call_generation_task.hpp include/reporttask.hpp \
-	include/rijndael.h include/scenario.hpp include/sip_parser.hpp \
-	include/screen.hpp include/socket.hpp include/socketowner.hpp \
-	include/stat.hpp include/strings.hpp include/task.hpp \
-	include/time.hpp include/variables.hpp include/watchdog.hpp \
-	include/xp_parser.h include/actions.hpp include/call.hpp \
-	include/auth.hpp include/deadcall.hpp include/sslcommon.h \
-	src/sslinit.c src/sslthreadsafe.c include/prepare_pcap.h \
-	include/send_packets.h src/prepare_pcap.c src/send_packets.c \
-	src/rtpstream.cpp include/rtpstream.hpp src/sipp.cpp \
-	include/sipp.hpp
+	src/call_generation_task.cpp src/ratetask.cpp \
+	src/reporttask.cpp src/rijndael.c src/scenario.cpp \
+	src/sip_parser.cpp src/screen.cpp src/socket.cpp \
+	src/socketowner.cpp src/stat.cpp src/strings.cpp src/task.cpp \
+	src/time.cpp src/variables.cpp src/watchdog.cpp \
+	src/xp_parser.c include/comp.h include/infile.hpp \
+	include/listener.hpp include/logger.hpp include/md5.h \
+	include/message.hpp include/milenage.h \
+	include/call_generation_task.hpp include/ratetask.hpp \
+	include/reporttask.hpp include/rijndael.h include/scenario.hpp \
+	include/sip_parser.hpp include/screen.hpp include/socket.hpp \
+	include/socketowner.hpp include/stat.hpp include/strings.hpp \
+	include/task.hpp include/time.hpp include/variables.hpp \
+	include/watchdog.hpp include/xp_parser.h include/actions.hpp \
+	include/call.hpp include/auth.hpp include/deadcall.hpp \
+	include/sslcommon.h src/sslinit.c src/sslthreadsafe.c \
+	include/prepare_pcap.h include/send_packets.h \
+	src/prepare_pcap.c src/send_packets.c src/rtpstream.cpp \
+	include/rtpstream.hpp src/sipp.cpp include/sipp.hpp
 am__dirstamp = $(am__leading_dot)dirstamp
 am__objects_1 =
 @HAVE_OPENSSL_TRUE@am__objects_2 = $(am__objects_1) \
@@ -143,15 +144,15 @@ am__objects_5 = src/sipp-actions.$(OBJEXT) src/sipp-auth.$(OBJEXT) \
 	src/sipp-md5.$(OBJEXT) src/sipp-message.$(OBJEXT) \
 	src/sipp-milenage.$(OBJEXT) \
 	src/sipp-call_generation_task.$(OBJEXT) \
-	src/sipp-reporttask.$(OBJEXT) src/sipp-rijndael.$(OBJEXT) \
-	src/sipp-scenario.$(OBJEXT) src/sipp-sip_parser.$(OBJEXT) \
-	src/sipp-screen.$(OBJEXT) src/sipp-socket.$(OBJEXT) \
-	src/sipp-socketowner.$(OBJEXT) src/sipp-stat.$(OBJEXT) \
-	src/sipp-strings.$(OBJEXT) src/sipp-task.$(OBJEXT) \
-	src/sipp-time.$(OBJEXT) src/sipp-variables.$(OBJEXT) \
-	src/sipp-watchdog.$(OBJEXT) src/sipp-xp_parser.$(OBJEXT) \
-	$(am__objects_1) $(am__objects_2) $(am__objects_3) \
-	$(am__objects_4)
+	src/sipp-ratetask.$(OBJEXT) src/sipp-reporttask.$(OBJEXT) \
+	src/sipp-rijndael.$(OBJEXT) src/sipp-scenario.$(OBJEXT) \
+	src/sipp-sip_parser.$(OBJEXT) src/sipp-screen.$(OBJEXT) \
+	src/sipp-socket.$(OBJEXT) src/sipp-socketowner.$(OBJEXT) \
+	src/sipp-stat.$(OBJEXT) src/sipp-strings.$(OBJEXT) \
+	src/sipp-task.$(OBJEXT) src/sipp-time.$(OBJEXT) \
+	src/sipp-variables.$(OBJEXT) src/sipp-watchdog.$(OBJEXT) \
+	src/sipp-xp_parser.$(OBJEXT) $(am__objects_1) $(am__objects_2) \
+	$(am__objects_3) $(am__objects_4)
 am_sipp_OBJECTS = $(am__objects_5) src/sipp-sipp.$(OBJEXT)
 sipp_OBJECTS = $(am_sipp_OBJECTS)
 sipp_DEPENDENCIES = @LIBOBJS@
@@ -160,23 +161,25 @@ sipp_LINK = $(CXXLD) $(sipp_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 am__sipp_unittest_SOURCES_DIST = src/actions.cpp src/auth.cpp \
 	src/comp.c src/call.cpp src/deadcall.cpp src/infile.cpp \
 	src/listener.cpp src/logger.cpp src/md5.c src/message.cpp \
-	src/milenage.c src/call_generation_task.cpp src/reporttask.cpp \
-	src/rijndael.c src/scenario.cpp src/sip_parser.cpp \
-	src/screen.cpp src/socket.cpp src/socketowner.cpp src/stat.cpp \
-	src/strings.cpp src/task.cpp src/time.cpp src/variables.cpp \
-	src/watchdog.cpp src/xp_parser.c include/comp.h \
-	include/infile.hpp include/listener.hpp include/logger.hpp \
-	include/md5.h include/message.hpp include/milenage.h \
-	include/call_generation_task.hpp include/reporttask.hpp \
-	include/rijndael.h include/scenario.hpp include/sip_parser.hpp \
-	include/screen.hpp include/socket.hpp include/socketowner.hpp \
-	include/stat.hpp include/strings.hpp include/task.hpp \
-	include/time.hpp include/variables.hpp include/watchdog.hpp \
-	include/xp_parser.h include/actions.hpp include/call.hpp \
-	include/auth.hpp include/deadcall.hpp include/sslcommon.h \
-	src/sslinit.c src/sslthreadsafe.c include/prepare_pcap.h \
-	include/send_packets.h src/prepare_pcap.c src/send_packets.c \
-	src/rtpstream.cpp include/rtpstream.hpp src/sipp_unittest.cpp \
+	src/milenage.c src/call_generation_task.cpp src/ratetask.cpp \
+	src/reporttask.cpp src/rijndael.c src/scenario.cpp \
+	src/sip_parser.cpp src/screen.cpp src/socket.cpp \
+	src/socketowner.cpp src/stat.cpp src/strings.cpp src/task.cpp \
+	src/time.cpp src/variables.cpp src/watchdog.cpp \
+	src/xp_parser.c include/comp.h include/infile.hpp \
+	include/listener.hpp include/logger.hpp include/md5.h \
+	include/message.hpp include/milenage.h \
+	include/call_generation_task.hpp include/ratetask.hpp \
+	include/reporttask.hpp include/rijndael.h include/scenario.hpp \
+	include/sip_parser.hpp include/screen.hpp include/socket.hpp \
+	include/socketowner.hpp include/stat.hpp include/strings.hpp \
+	include/task.hpp include/time.hpp include/variables.hpp \
+	include/watchdog.hpp include/xp_parser.h include/actions.hpp \
+	include/call.hpp include/auth.hpp include/deadcall.hpp \
+	include/sslcommon.h src/sslinit.c src/sslthreadsafe.c \
+	include/prepare_pcap.h include/send_packets.h \
+	src/prepare_pcap.c src/send_packets.c src/rtpstream.cpp \
+	include/rtpstream.hpp src/sipp_unittest.cpp \
 	src/xp_parser_ut.cpp ./gtest/src/gtest-all.cc \
 	./gtest/src/gtest_main.cc
 @HAVE_OPENSSL_TRUE@am__objects_6 = $(am__objects_1) \
@@ -198,6 +201,7 @@ am__objects_9 = src/sipp_unittest-actions.$(OBJEXT) \
 	src/sipp_unittest-message.$(OBJEXT) \
 	src/sipp_unittest-milenage.$(OBJEXT) \
 	src/sipp_unittest-call_generation_task.$(OBJEXT) \
+	src/sipp_unittest-ratetask.$(OBJEXT) \
 	src/sipp_unittest-reporttask.$(OBJEXT) \
 	src/sipp_unittest-rijndael.$(OBJEXT) \
 	src/sipp_unittest-scenario.$(OBJEXT) \
@@ -648,6 +652,7 @@ common_incl = include/comp.h \
 	        include/message.hpp \
 	        include/milenage.h \
 	        include/call_generation_task.hpp \
+	        include/ratetask.hpp \
 	        include/reporttask.hpp \
 	        include/rijndael.h \
 	        include/scenario.hpp \
@@ -679,6 +684,7 @@ common_SOURCES = src/actions.cpp \
 	       src/message.cpp \
 	       src/milenage.c \
 	       src/call_generation_task.cpp \
+	       src/ratetask.cpp \
 	       src/reporttask.cpp \
 	       src/rijndael.c \
 	       src/scenario.cpp \
@@ -842,6 +848,8 @@ src/sipp-milenage.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/sipp-call_generation_task.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
+src/sipp-ratetask.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/sipp-reporttask.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/sipp-rijndael.$(OBJEXT): src/$(am__dirstamp) \
@@ -909,6 +917,8 @@ src/sipp_unittest-message.$(OBJEXT): src/$(am__dirstamp) \
 src/sipp_unittest-milenage.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/sipp_unittest-call_generation_task.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
+src/sipp_unittest-ratetask.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/sipp_unittest-reporttask.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
@@ -990,6 +1000,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp-message.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp-milenage.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp-prepare_pcap.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp-ratetask.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp-reporttask.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp-rijndael.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp-rtpstream.Po@am__quote@
@@ -1022,6 +1033,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp_unittest-message.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp_unittest-milenage.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp_unittest-prepare_pcap.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp_unittest-ratetask.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp_unittest-reporttask.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp_unittest-rijndael.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/sipp_unittest-rtpstream.Po@am__quote@
@@ -1453,6 +1465,20 @@ src/sipp-call_generation_task.obj: src/call_generation_task.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_CXXFLAGS) $(CXXFLAGS) -c -o src/sipp-call_generation_task.obj `if test -f 'src/call_generation_task.cpp'; then $(CYGPATH_W) 'src/call_generation_task.cpp'; else $(CYGPATH_W) '$(srcdir)/src/call_generation_task.cpp'; fi`
 
+src/sipp-ratetask.o: src/ratetask.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_CXXFLAGS) $(CXXFLAGS) -MT src/sipp-ratetask.o -MD -MP -MF src/$(DEPDIR)/sipp-ratetask.Tpo -c -o src/sipp-ratetask.o `test -f 'src/ratetask.cpp' || echo '$(srcdir)/'`src/ratetask.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/sipp-ratetask.Tpo src/$(DEPDIR)/sipp-ratetask.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/ratetask.cpp' object='src/sipp-ratetask.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_CXXFLAGS) $(CXXFLAGS) -c -o src/sipp-ratetask.o `test -f 'src/ratetask.cpp' || echo '$(srcdir)/'`src/ratetask.cpp
+
+src/sipp-ratetask.obj: src/ratetask.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_CXXFLAGS) $(CXXFLAGS) -MT src/sipp-ratetask.obj -MD -MP -MF src/$(DEPDIR)/sipp-ratetask.Tpo -c -o src/sipp-ratetask.obj `if test -f 'src/ratetask.cpp'; then $(CYGPATH_W) 'src/ratetask.cpp'; else $(CYGPATH_W) '$(srcdir)/src/ratetask.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/sipp-ratetask.Tpo src/$(DEPDIR)/sipp-ratetask.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/ratetask.cpp' object='src/sipp-ratetask.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_CXXFLAGS) $(CXXFLAGS) -c -o src/sipp-ratetask.obj `if test -f 'src/ratetask.cpp'; then $(CYGPATH_W) 'src/ratetask.cpp'; else $(CYGPATH_W) '$(srcdir)/src/ratetask.cpp'; fi`
+
 src/sipp-reporttask.o: src/reporttask.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_CXXFLAGS) $(CXXFLAGS) -MT src/sipp-reporttask.o -MD -MP -MF src/$(DEPDIR)/sipp-reporttask.Tpo -c -o src/sipp-reporttask.o `test -f 'src/reporttask.cpp' || echo '$(srcdir)/'`src/reporttask.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/sipp-reporttask.Tpo src/$(DEPDIR)/sipp-reporttask.Po
@@ -1774,6 +1800,20 @@ src/sipp_unittest-call_generation_task.obj: src/call_generation_task.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/call_generation_task.cpp' object='src/sipp_unittest-call_generation_task.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_unittest_CXXFLAGS) $(CXXFLAGS) -c -o src/sipp_unittest-call_generation_task.obj `if test -f 'src/call_generation_task.cpp'; then $(CYGPATH_W) 'src/call_generation_task.cpp'; else $(CYGPATH_W) '$(srcdir)/src/call_generation_task.cpp'; fi`
+
+src/sipp_unittest-ratetask.o: src/ratetask.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_unittest_CXXFLAGS) $(CXXFLAGS) -MT src/sipp_unittest-ratetask.o -MD -MP -MF src/$(DEPDIR)/sipp_unittest-ratetask.Tpo -c -o src/sipp_unittest-ratetask.o `test -f 'src/ratetask.cpp' || echo '$(srcdir)/'`src/ratetask.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/sipp_unittest-ratetask.Tpo src/$(DEPDIR)/sipp_unittest-ratetask.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/ratetask.cpp' object='src/sipp_unittest-ratetask.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_unittest_CXXFLAGS) $(CXXFLAGS) -c -o src/sipp_unittest-ratetask.o `test -f 'src/ratetask.cpp' || echo '$(srcdir)/'`src/ratetask.cpp
+
+src/sipp_unittest-ratetask.obj: src/ratetask.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_unittest_CXXFLAGS) $(CXXFLAGS) -MT src/sipp_unittest-ratetask.obj -MD -MP -MF src/$(DEPDIR)/sipp_unittest-ratetask.Tpo -c -o src/sipp_unittest-ratetask.obj `if test -f 'src/ratetask.cpp'; then $(CYGPATH_W) 'src/ratetask.cpp'; else $(CYGPATH_W) '$(srcdir)/src/ratetask.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/sipp_unittest-ratetask.Tpo src/$(DEPDIR)/sipp_unittest-ratetask.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/ratetask.cpp' object='src/sipp_unittest-ratetask.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_unittest_CXXFLAGS) $(CXXFLAGS) -c -o src/sipp_unittest-ratetask.obj `if test -f 'src/ratetask.cpp'; then $(CYGPATH_W) 'src/ratetask.cpp'; else $(CYGPATH_W) '$(srcdir)/src/ratetask.cpp'; fi`
 
 src/sipp_unittest-reporttask.o: src/reporttask.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(sipp_unittest_CXXFLAGS) $(CXXFLAGS) -MT src/sipp_unittest-reporttask.o -MD -MP -MF src/$(DEPDIR)/sipp_unittest-reporttask.Tpo -c -o src/sipp_unittest-reporttask.o `test -f 'src/reporttask.cpp' || echo '$(srcdir)/'`src/reporttask.cpp

--- a/include/ratetask.hpp
+++ b/include/ratetask.hpp
@@ -1,0 +1,50 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  Author : Richard GAYRAUD - 04 Nov 2003
+ *           Marc LAMBERTON
+ *           Olivier JACQUES
+ *           Herve PELLAN
+ *           David MANSUTTI
+ *           Francois-Xavier Kowalski
+ *           Gerard Lyonnaz
+ *           From Hewlett Packard Company.
+ *           F. Tarek Rogers
+ *           Peter Higginson
+ *           Vincent Luba
+ *           Shriram Natarajan
+ *           Guillaume Teissier from FTR&D
+ *           Clement Chen
+ *           Wolfgang Beck
+ *           Charles P Wright from IBM Research
+ */
+
+#ifndef RATETASK_HPP
+#define RATETASK_HPP
+
+#include "task.hpp"
+
+class ratetask : public task
+{
+public:
+    unsigned int wake();
+    static void initialize();
+    bool run();
+    void dump();
+private:
+    static class ratetask *instance;
+};
+
+#endif

--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -82,6 +82,7 @@
 #include "infile.hpp"
 #include "call_generation_task.hpp"
 #include "reporttask.hpp"
+#include "ratetask.hpp"
 #include "watchdog.hpp"
 /* Open SSL stuff */
 #ifdef _USE_OPENSSL
@@ -162,6 +163,7 @@ cmd messages are received */
 #define DEFAULT_SERVICE              ((char *)"service")
 #define DEFAULT_AUTH_PASSWORD        ((char *)"password")
 #define DEFAULT_REPORT_FREQ          1000
+#define DEFAULT_RATE_INCR_FREQ       60000
 #define DEFAULT_REPORT_FREQ_DUMP_LOG 60000
 #define DEFAULT_TIMER_RESOLUTION     1
 #define DEFAULT_FREQ_DUMP_RTT        200
@@ -190,6 +192,7 @@ extern double             rate                    _DEFVAL(DEFAULT_RATE);
 extern double             rate_scale              _DEFVAL(DEFAULT_RATE_SCALE);
 extern int	          rate_increase           _DEFVAL(0);
 extern int	          rate_max	          _DEFVAL(0);
+extern unsigned long      rate_increase_freq      _DEFVAL(DEFAULT_RATE_INCR_FREQ);
 extern bool	          rate_quit		  _DEFVAL(true);
 extern int                users                   _DEFVAL(-1);
 extern int               rate_period_ms           _DEFVAL(DEFAULT_RATE_PERIOD_MS);
@@ -391,6 +394,7 @@ extern int           last_paused_calls            _DEFVAL(0);
 extern unsigned int  open_calls_allowed           _DEFVAL(0);
 extern unsigned long last_report_time             _DEFVAL(0);
 extern unsigned long last_dump_time               _DEFVAL(0);
+extern unsigned long last_rate_increase_time      _DEFVAL(0);
 
 /********************** Clock variables ***********************/
 

--- a/src/ratetask.cpp
+++ b/src/ratetask.cpp
@@ -1,0 +1,78 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  Author : Richard GAYRAUD - 04 Nov 2003
+ *           Marc LAMBERTON
+ *           Olivier JACQUES
+ *           Herve PELLAN
+ *           David MANSUTTI
+ *           Francois-Xavier Kowalski
+ *           Gerard Lyonnaz
+ *           From Hewlett Packard Company.
+ *           F. Tarek Rogers
+ *           Peter Higginson
+ *           Vincent Luba
+ *           Shriram Natarajan
+ *           Guillaume Teissier from FTR&D
+ *           Clement Chen
+ *           Wolfgang Beck
+ *           Charles P Wright from IBM Research
+ */
+#include "sipp.hpp"
+
+class ratetask *ratetask::instance = NULL;
+
+void ratetask::initialize()
+{
+    assert(instance == NULL);
+    if (rate_increase) {
+        instance = new ratetask();
+    }
+}
+
+void ratetask::dump()
+{
+    WARNING("Increasing call rate task.");
+}
+
+bool ratetask::run()
+{
+    if (quitting >= 10) {
+        delete this;
+        return false;
+    }
+
+    /* Statistics Logs. */
+    if ((getmilliseconds() - last_rate_increase_time) >= rate_increase_freq)  {
+        if (rate_increase) {
+            rate += rate_increase;
+            if (rate_max && (rate > rate_max)) {
+                rate = rate_max;
+                if (rate_quit) {
+                    quitting += 10;
+                }
+            }
+            CallGenerationTask::set_rate(rate);
+            last_rate_increase_time = clock_tick;
+        }
+    }
+    setPaused();
+    return true;
+}
+
+unsigned int ratetask::wake()
+{
+    return last_rate_increase_time + rate_increase_freq;
+}

--- a/src/reporttask.cpp
+++ b/src/reporttask.cpp
@@ -38,7 +38,7 @@ class screentask *screentask::instance = NULL;
 void stattask::initialize()
 {
     assert(instance == NULL);
-    if (dumpInFile || useCountf || useErrorCodesf || rate_increase) {
+    if (dumpInFile || useCountf || useErrorCodesf) {
         instance = new stattask();
     }
 }
@@ -109,16 +109,6 @@ bool stattask::run()
 {
     /* Statistics Logs. */
     if((getmilliseconds() - last_dump_time) >= report_freq_dumpLog)  {
-        if (rate_increase) {
-            rate += rate_increase;
-            if (rate_max && (rate > rate_max)) {
-                rate = rate_max;
-                if (rate_quit) {
-                    quitting += 10;
-                }
-            }
-            CallGenerationTask::set_rate(rate);
-        }
         report();
     }
     setPaused();
@@ -129,3 +119,4 @@ unsigned int stattask::wake()
 {
     return last_dump_time + report_freq_dumpLog;
 }
+

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -273,12 +273,13 @@ struct sipp_option options_table[] = {
      "Example: -r 7 -rp 2000 ==> 7 calls every 2 seconds.\n         -r 10 -rp 5s => 10 calls every 5 seconds.", SIPP_OPTION_TIME_MS, &rate_period_ms, 1},
     {"rate_scale", "Control the units for the '+', '-', '*', and '/' keys.", SIPP_OPTION_FLOAT, &rate_scale, 1},
 
-    {"rate_increase", "Specify the rate increase every -fd units (default is seconds).  This allows you to increase the load for each independent logging period.\n"
-     "Example: -rate_increase 10 -fd 10s\n"
+    {"rate_increase", "Specify the rate increase every -rate_interval units (default is seconds).  This allows you to increase the load for each independent logging period.\n"
+     "Example: -rate_increase 10 -rate_interval 10s\n"
      "  ==> increase calls by 10 every 10 seconds.", SIPP_OPTION_INT, &rate_increase, 1},
     {"rate_max", "If -rate_increase is set, then quit after the rate reaches this value.\n"
      "Example: -rate_increase 10 -rate_max 100\n"
      "  ==> increase calls by 10 until 100 cps is hit.", SIPP_OPTION_INT, &rate_max, 1},
+    {"rate_interval", "Set the interval by which the call rate is increased. Default is 60 and default unit is seconds.", SIPP_OPTION_TIME_SEC, &rate_increase_freq, 1},
     {"no_rate_quit", "If -rate_increase is set, do not quit after the rate reaches -rate_max.", SIPP_OPTION_UNSETFLAG, &rate_quit, 1},
 
     {"l", "Set the maximum number of simultaneous calls. Once this limit is reached, traffic is decreased until the number of open calls goes down. Default:\n"
@@ -1940,6 +1941,8 @@ int main(int argc, char *argv[])
     stattask::initialize();
     /* Create the screen update task. */
     screentask::initialize();
+    /* Create the rate increase task. */
+    ratetask::initialize();
     /* Create a watchdog task. */
     if (watchdog_interval) {
         new watchdog(watchdog_interval, watchdog_reset, watchdog_major_threshold, watchdog_major_maxtriggers, watchdog_minor_threshold, watchdog_minor_maxtriggers);


### PR DESCRIPTION
For several load tests, I want to have finer-grained statistics coming from SIPp, so I have the `-fd` option set to `1s`.  However, this means that if I want to use the automatic rate increases, I'm stuck with either coarser stats, or a less-useful ramp-up time.

This PR is an attempt to move call rate increases into a separate task.

Note: I have not yet been able to test this because I'm having trouble with the autotools. I'll put those details into a comment.