### PR TITLE
Start using config.h, and use it for HAVE_PCAP_NEXT_EX.

### DIFF
--- a/configure
+++ b/configure
@@ -1940,60 +1940,6 @@ $as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_func
-
-# ac_fn_c_find_uintX_t LINENO BITS VAR
-# ------------------------------------
-# Finds an unsigned integer type with width BITS, setting cache variable VAR
-# accordingly.
-ac_fn_c_find_uintX_t ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for uint$2_t" >&5
-$as_echo_n "checking for uint$2_t... " >&6; }
-if eval \${$3+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  eval "$3=no"
-     # Order is important - never check a type that is potentially smaller
-     # than half of the expected target width.
-     for ac_type in uint$2_t 'unsigned int' 'unsigned long int' \
-	 'unsigned long long int' 'unsigned short int' 'unsigned char'; do
-       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$ac_includes_default
-int
-main ()
-{
-static int test_array [1 - 2 * !((($ac_type) -1 >> ($2 / 2 - 1)) >> ($2 / 2 - 1) == 3)];
-test_array [0] = 0;
-return test_array [0];
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  case $ac_type in #(
-  uint$2_t) :
-    eval "$3=yes" ;; #(
-  *) :
-    eval "$3=\$ac_type" ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-       if eval test \"x\$"$3"\" = x"no"; then :
-
-else
-  break
-fi
-     done
-fi
-eval ac_res=\$$3
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-
-} # ac_fn_c_find_uintX_t
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -7352,64 +7298,6 @@ else
   as_fn_error $? "pcap library missing" "$LINENO" 5
 fi
 
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing pcap_next_ex" >&5
-$as_echo_n "checking for library containing pcap_next_ex... " >&6; }
-if ${ac_cv_search_pcap_next_ex+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_func_search_save_LIBS=$LIBS
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char pcap_next_ex ();
-int
-main ()
-{
-return pcap_next_ex ();
-  ;
-  return 0;
-}
-_ACEOF
-for ac_lib in '' pcap wpcap; do
-  if test -z "$ac_lib"; then
-    ac_res="none required"
-  else
-    ac_res=-l$ac_lib
-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
-  fi
-  if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_search_pcap_next_ex=$ac_res
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext
-  if ${ac_cv_search_pcap_next_ex+:} false; then :
-  break
-fi
-done
-if ${ac_cv_search_pcap_next_ex+:} false; then :
-
-else
-  ac_cv_search_pcap_next_ex=no
-fi
-rm conftest.$ac_ext
-LIBS=$ac_func_search_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_pcap_next_ex" >&5
-$as_echo "$ac_cv_search_pcap_next_ex" >&6; }
-ac_res=$ac_cv_search_pcap_next_ex
-if test "$ac_res" != no; then :
-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-
-else
-  as_fn_error $? "pcap library missing" "$LINENO" 5
-fi
-
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing pcap_close" >&5
 $as_echo_n "checking for library containing pcap_close... " >&6; }
 if ${ac_cv_search_pcap_close+:} false; then :
@@ -7466,6 +7354,48 @@ if test "$ac_res" != no; then :
 
 else
   as_fn_error $? "pcap library missing" "$LINENO" 5
+fi
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pcap_next_ex in -lpcap" >&5
+$as_echo_n "checking for pcap_next_ex in -lpcap... " >&6; }
+if ${ac_cv_lib_pcap_pcap_next_ex+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lpcap  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pcap_next_ex ();
+int
+main ()
+{
+return pcap_next_ex ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_pcap_pcap_next_ex=yes
+else
+  ac_cv_lib_pcap_pcap_next_ex=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pcap_pcap_next_ex" >&5
+$as_echo "$ac_cv_lib_pcap_pcap_next_ex" >&6; }
+if test "x$ac_cv_lib_pcap_pcap_next_ex" = xyes; then :
+
+$as_echo "#define HAVE_PCAP_NEXT_EX 1" >>confdefs.h
+
 fi
 
 fi
@@ -8172,46 +8102,10 @@ _ACEOF
 
 fi
 
-ac_fn_c_find_uintX_t "$LINENO" "16" "ac_cv_c_uint16_t"
-case $ac_cv_c_uint16_t in #(
-  no|yes) ;; #(
-  *)
-
-
-cat >>confdefs.h <<_ACEOF
-#define uint16_t $ac_cv_c_uint16_t
-_ACEOF
-;;
-  esac
-
-ac_fn_c_find_uintX_t "$LINENO" "32" "ac_cv_c_uint32_t"
-case $ac_cv_c_uint32_t in #(
-  no|yes) ;; #(
-  *)
-
-$as_echo "#define _UINT32_T 1" >>confdefs.h
-
-
-cat >>confdefs.h <<_ACEOF
-#define uint32_t $ac_cv_c_uint32_t
-_ACEOF
-;;
-  esac
-
-ac_fn_c_find_uintX_t "$LINENO" "8" "ac_cv_c_uint8_t"
-case $ac_cv_c_uint8_t in #(
-  no|yes) ;; #(
-  *)
-
-$as_echo "#define _UINT8_T 1" >>confdefs.h
-
-
-cat >>confdefs.h <<_ACEOF
-#define uint8_t $ac_cv_c_uint8_t
-_ACEOF
-;;
-  esac
-
+# These conflict with netinet/in.h typedefs.
+#AC_TYPE_UINT16_T
+#AC_TYPE_UINT32_T
+#AC_TYPE_UINT8_T
 
 # ==================== checks for library functions =====================
 

--- a/configure.ac
+++ b/configure.ac
@@ -138,8 +138,8 @@ if test "$pcap" = 'yes'; then
 	AC_CHECK_HEADERS([pcap.h],,[AC_MSG_ERROR([<pcap.h> header missing])])
 	AC_SEARCH_LIBS([pcap_open_offline],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
 	AC_SEARCH_LIBS([pcap_next],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
-	AC_SEARCH_LIBS([pcap_next_ex],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
 	AC_SEARCH_LIBS([pcap_close],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
+	AC_CHECK_LIB([pcap],[pcap_next_ex],AC_DEFINE([HAVE_PCAP_NEXT_EX],[1],[Define to 1 if libpcap has the pcap_next_ex function.]))
 fi
 # For Makefile.am
 AM_CONDITIONAL(HAVE_PCAP, test "$pcap" = "yes")
@@ -186,9 +186,10 @@ AC_C_INLINE
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T
-AC_TYPE_UINT16_T
-AC_TYPE_UINT32_T
-AC_TYPE_UINT8_T
+# These conflict with netinet/in.h typedefs.
+#AC_TYPE_UINT16_T
+#AC_TYPE_UINT32_T
+#AC_TYPE_UINT8_T
 
 # ==================== checks for library functions =====================
 

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -114,6 +114,9 @@
 /* Define to 1 if you have the <pcap.h> header file. */
 #undef HAVE_PCAP_H
 
+/* Define to 1 if libpcap has the pcap_next_ex function. */
+#undef HAVE_PCAP_NEXT_EX
+
 /* Define to 1 if you have the `pow' function. */
 #undef HAVE_POW
 
@@ -239,16 +242,6 @@
 /* Version number of package */
 #undef VERSION
 
-/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
-   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
-   #define below would cause a syntax error. */
-#undef _UINT32_T
-
-/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
-   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
-   #define below would cause a syntax error. */
-#undef _UINT8_T
-
 /* Define to `__inline__' or `__inline' if that's what the C compiler
    calls it, or to nothing if 'inline' is not supported under any name.  */
 #ifndef __cplusplus
@@ -263,18 +256,6 @@
 
 /* Define to `int' if <sys/types.h> does not define. */
 #undef ssize_t
-
-/* Define to the type of an unsigned integer type of width exactly 16 bits if
-   such a type exists and the standard includes do not define it. */
-#undef uint16_t
-
-/* Define to the type of an unsigned integer type of width exactly 32 bits if
-   such a type exists and the standard includes do not define it. */
-#undef uint32_t
-
-/* Define to the type of an unsigned integer type of width exactly 8 bits if
-   such a type exists and the standard includes do not define it. */
-#undef uint8_t
 
 /* Define as `fork' if `vfork' does not work. */
 #undef vfork

--- a/src/prepare_pcap.c
+++ b/src/prepare_pcap.c
@@ -15,6 +15,10 @@
  *
  *  Author : Guillaume TEISSIER from FTR&D 02/02/2006
  */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <pcap.h>
 #include <stdlib.h>
 #include <netinet/in.h>
@@ -198,4 +202,3 @@ int prepare_pkts(char *file, pcap_pkts *pkts)
 
     return 0;
 }
-


### PR DESCRIPTION
In #110, @vodik reported that HAVE_PCAP_NEXT_EX was unused. This
changeset does the following:
- Remove uint8_t and friends from configure.ac because the resulting
  defines (`define uint8_t unsigned char`) conflict with typedefs from
  `netinet/in.h`.
- Include `config.h` from `prepare_pcap.c`.
- Fix so HAVE_PCAP_NEXT_EX is defined in config.h if available.

TODO: We should move HAVE_EPOLL from the Makefile.am CFLAGS addition to
config.h inclusion as well.
