### PR TITLE
Fix `make dist` target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,13 +9,12 @@ AM_CPPFLAGS=$(AM_CFLAGS)
 
 CLEANFILES =
 EXTRA_DIST = \
-	src/fortune.cpp \
-	pcap \
-	LICENSE.txt \
-	README.txt \
-	THANKS \
-	sipp.dtd \
-	cpplint.py
+	$(srcdir)/src/fortune.cpp \
+	$(srcdir)/LICENSE.txt \
+	$(srcdir)/README.md \
+	$(srcdir)/THANKS \
+	$(srcdir)/sipp.dtd \
+	$(srcdir)/cpplint.py
 
 if HAVE_OPENSSL
 DEFS += -D_USE_OPENSSL
@@ -128,12 +127,42 @@ sipp_CFLAGS = $(AM_CFLAGS) @GSL_CFLAGS@
 sipp_CXXFLAGS = $(AM_CXXFLAGS) @GSL_CXXFLAGS@
 sipp_LDADD = @LIBOBJS@ @GSL_LIBS@
 
+gtest_SOURCES = \
+	gtest/include/gtest/gtest-death-test.h \
+	gtest/include/gtest/gtest-message.h \
+	gtest/include/gtest/gtest-param-test.h \
+	gtest/include/gtest/gtest-printers.h \
+	gtest/include/gtest/gtest-spi.h \
+	gtest/include/gtest/gtest-test-part.h \
+	gtest/include/gtest/gtest-typed-test.h \
+	gtest/include/gtest/gtest.h \
+	gtest/include/gtest/gtest_pred_impl.h \
+	gtest/include/gtest/gtest_prod.h \
+	gtest/include/gtest/internal/gtest-death-test-internal.h \
+	gtest/include/gtest/internal/gtest-filepath.h \
+	gtest/include/gtest/internal/gtest-internal.h \
+	gtest/include/gtest/internal/gtest-linked_ptr.h \
+	gtest/include/gtest/internal/gtest-param-util-generated.h \
+	gtest/include/gtest/internal/gtest-param-util.h \
+	gtest/include/gtest/internal/gtest-port.h \
+	gtest/include/gtest/internal/gtest-string.h \
+	gtest/include/gtest/internal/gtest-tuple.h \
+	gtest/include/gtest/internal/gtest-type-util.h \
+	gtest/src/gtest-death-test.cc \
+	gtest/src/gtest-filepath.cc \
+	gtest/src/gtest-internal-inl.h \
+	gtest/src/gtest-port.cc \
+	gtest/src/gtest-printers.cc \
+	gtest/src/gtest-test-part.cc \
+	gtest/src/gtest-typed-test.cc \
+	gtest/src/gtest.cc \
+	gtest/src/gtest_main.cc
+
 sipp_unittest_SOURCES = \
 	$(common_SOURCES) \
 	src/sipp_unittest.cpp \
 	src/xp_parser_ut.cpp \
-	./gtest/src/gtest-all.cc \
-	./gtest/src/gtest_main.cc
+	$(gtest_SOURCES)
 
 sipp_unittest_CFLAGS = $(AM_CFLAGS) -DGTEST=1 -I$(srcdir)/gtest/include -I$(srcdir)/gtest @GSL_CFLAGS@
 sipp_unittest_CXXFLAGS = $(AM_CXXFLAGS) -DGTEST=1 -I$(srcdir)/gtest/include -I$(srcdir)/gtest @GSL_CXXFLAGS@

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,28 +8,41 @@ AM_CFLAGS=-I$(srcdir)/include
 AM_CPPFLAGS=$(AM_CFLAGS)
 
 CLEANFILES =
-EXTRA_DIST = src/fortune.cpp pcap LICENSE.txt README.txt THANKS sipp.dtd cpplint.py
+EXTRA_DIST = \
+	src/fortune.cpp \
+	pcap \
+	LICENSE.txt \
+	README.txt \
+	THANKS \
+	sipp.dtd \
+	cpplint.py
 
 if HAVE_OPENSSL
 DEFS += -D_USE_OPENSSL
-ssl_incl = include/sslcommon.h
-ssl_SOURCES = $(ssl_incl) \
-              src/sslinit.c \
-	      src/sslthreadsafe.c
+ssl_incl = \
+	include/sslcommon.h
+ssl_SOURCES = \
+	$(ssl_incl) \
+	src/sslinit.c \
+	src/sslthreadsafe.c
 endif
 
 if HAVE_PCAP
 DEFS += -DPCAPPLAY
-pcap_incl = include/prepare_pcap.h \
-	       include/send_packets.h
-pcap_SOURCES = $(pcap_incl) \
-               src/prepare_pcap.c \
-	       src/send_packets.c
+pcap_incl = \
+	include/prepare_pcap.h \
+	include/send_packets.h
+pcap_SOURCES = \
+	$(pcap_incl) \
+	src/prepare_pcap.c \
+	src/send_packets.c
 endif
 
 if HAVE_RTP
 DEFS += -DRTP_STREAM
-rtp_SOURCES = src/rtpstream.cpp include/rtpstream.hpp
+rtp_SOURCES = \
+	src/rtpstream.cpp \
+	include/rtpstream.hpp
 endif
 
 if HAVE_SCTP
@@ -44,75 +57,79 @@ if HAVE_EPOLL
 DEFS += -DHAVE_EPOLL
 endif
 
-common_incl = include/comp.h \
-	        include/infile.hpp \
-	        include/listener.hpp \
-	        include/logger.hpp \
-	        include/md5.h \
-	        include/message.hpp \
-	        include/milenage.h \
-	        include/call_generation_task.hpp \
-	        include/ratetask.hpp \
-	        include/reporttask.hpp \
-	        include/rijndael.h \
-	        include/scenario.hpp \
-	        include/sip_parser.hpp \
-	        include/screen.hpp \
-	        include/socket.hpp \
-	        include/socketowner.hpp \
-	        include/stat.hpp \
-	        include/strings.hpp \
-	        include/task.hpp \
-	        include/time.hpp \
-	        include/variables.hpp \
-	        include/watchdog.hpp \
-	        include/xp_parser.h \
-	        include/actions.hpp \
-	        include/call.hpp \
-	        include/auth.hpp \
-	        include/deadcall.hpp
+common_incl = \
+	include/comp.h \
+	include/infile.hpp \
+	include/listener.hpp \
+	include/logger.hpp \
+	include/md5.h \
+	include/message.hpp \
+	include/milenage.h \
+	include/call_generation_task.hpp \
+	include/ratetask.hpp \
+	include/reporttask.hpp \
+	include/rijndael.h \
+	include/scenario.hpp \
+	include/sip_parser.hpp \
+	include/screen.hpp \
+	include/socket.hpp \
+	include/socketowner.hpp \
+	include/stat.hpp \
+	include/strings.hpp \
+	include/task.hpp \
+	include/time.hpp \
+	include/variables.hpp \
+	include/watchdog.hpp \
+	include/xp_parser.h \
+	include/actions.hpp \
+	include/call.hpp \
+	include/auth.hpp \
+	include/deadcall.hpp
 
-common_SOURCES = src/actions.cpp \
-	       src/auth.cpp \
-	       src/comp.c \
-	       src/call.cpp \
-	       src/deadcall.cpp \
-	       src/infile.cpp \
-	       src/listener.cpp \
-	       src/logger.cpp \
-	       src/md5.c \
-	       src/message.cpp \
-	       src/milenage.c \
-	       src/call_generation_task.cpp \
-	       src/ratetask.cpp \
-	       src/reporttask.cpp \
-	       src/rijndael.c \
-	       src/scenario.cpp \
-	       src/sip_parser.cpp \
-	       src/screen.cpp \
-	       src/socket.cpp \
-	       src/socketowner.cpp \
-	       src/stat.cpp \
-	       src/strings.cpp \
-	       src/task.cpp \
-	       src/time.cpp \
-	       src/variables.cpp \
-	       src/watchdog.cpp \
-	       src/xp_parser.c \
-	       $(common_incl) \
-	       $(ssl_SOURCES) \
-	       $(pcap_SOURCES) \
-		   $(rtp_SOURCES)
+common_SOURCES = \
+	src/actions.cpp \
+	src/auth.cpp \
+	src/comp.c \
+	src/call.cpp \
+	src/deadcall.cpp \
+	src/infile.cpp \
+	src/listener.cpp \
+	src/logger.cpp \
+	src/md5.c \
+	src/message.cpp \
+	src/milenage.c \
+	src/call_generation_task.cpp \
+	src/ratetask.cpp \
+	src/reporttask.cpp \
+	src/rijndael.c \
+	src/scenario.cpp \
+	src/sip_parser.cpp \
+	src/screen.cpp \
+	src/socket.cpp \
+	src/socketowner.cpp \
+	src/stat.cpp \
+	src/strings.cpp \
+	src/task.cpp \
+	src/time.cpp \
+	src/variables.cpp \
+	src/watchdog.cpp \
+	src/xp_parser.c \
+	$(common_incl) \
+	$(ssl_SOURCES) \
+	$(pcap_SOURCES) \
+	$(rtp_SOURCES)
 
-sipp_SOURCES = $(common_SOURCES) \
-	       src/sipp.cpp \
-	       include/sipp.hpp
+sipp_SOURCES = \
+	$(common_SOURCES) \
+	src/sipp.cpp \
+	include/sipp.hpp
 
 sipp_CFLAGS = $(AM_CFLAGS) @GSL_CFLAGS@
 sipp_CXXFLAGS = $(AM_CXXFLAGS) @GSL_CXXFLAGS@
 sipp_LDADD = @LIBOBJS@ @GSL_LIBS@
 
-sipp_unittest_SOURCES = $(common_SOURCES) \
+sipp_unittest_SOURCES = \
+	$(common_SOURCES) \
 	src/sipp_unittest.cpp \
 	src/xp_parser_ut.cpp \
 	./gtest/src/gtest-all.cc \

--- a/configure.ac
+++ b/configure.ac
@@ -23,8 +23,7 @@ AC_ARG_WITH([gsl],AC_HELP_STRING([--with-gsl], [build with GSL (GNU Scientific L
 AC_PATH_PROG([HELP2MAN], help2man)
 AM_CONDITIONAL([HAVE_HELP2MAN], [test -n "$HELP2MAN"])
 if test x"$HELP2MAN" = x; then
-	AC_MSG_WARN([cannot find help2man, you will not be able to generate
-		manpages])
+    AC_MSG_WARN([cannot find help2man, you will not be able to generate manpages])
 fi
 
 # ==================== basic compiler settings ==========================
@@ -34,42 +33,42 @@ AC_PROG_CXX
 AC_HEADER_STDC
 
 case "$host" in
-	*-linux*)
-		CFLAGS="$CFLAGS -D__LINUX"
-		CPPFLAGS="$CPPFLAGS -D__LINUX"
-		;;
-	*-darwin*)
-		CFLAGS="$CFLAGS -D__DARWIN"
-		CPPFLAGS="$CPPFLAGS -D__DARWIN"
-		;;
-	*-hpux*)
-		CFLAGS="$CFLAGS -D__HPUX"
-		CPPFLAGS="$CPPFLAGS -D__HPUX"
-		;;
-	*-freebsd*)
-		CFLAGS="$CFLAGS -D__LINUX -I/usr/local/include"
-		CPPFLAGS="$CPPFLAGS -D__LINUX -I/usr/local/include"
+    *-linux*)
+        CFLAGS="$CFLAGS -D__LINUX"
+        CPPFLAGS="$CPPFLAGS -D__LINUX"
+        ;;
+    *-darwin*)
+        CFLAGS="$CFLAGS -D__DARWIN"
+        CPPFLAGS="$CPPFLAGS -D__DARWIN"
+        ;;
+    *-hpux*)
+        CFLAGS="$CFLAGS -D__HPUX"
+        CPPFLAGS="$CPPFLAGS -D__HPUX"
+        ;;
+    *-freebsd*)
+        CFLAGS="$CFLAGS -D__LINUX -I/usr/local/include"
+        CPPFLAGS="$CPPFLAGS -D__LINUX -I/usr/local/include"
         LDFLAGS="$LDFLAGS -L/usr/local/lib"
-		;;
-	*-sunos*)
-		CFLAGS="$CFLAGS -D__SUNOS"
-		CPPFLAGS="$CPPFLAGS -D__SUNOS"
-		;;
-	*-cygwin*)
-		CFLAGS="$CFLAGS -D__CYGWIN -I /usr/include/ncurses -I /usr/lib/WpdPack/Include -I /usr/include/SctpDrv"
-		CPPFLAGS="$CPPFLAGS -D__CYGWIN -I /usr/include/ncurses -I /usr/lib/WpdPack/Include -I /usr/include/SctpDrv"
+        ;;
+    *-sunos*)
+        CFLAGS="$CFLAGS -D__SUNOS"
+        CPPFLAGS="$CPPFLAGS -D__SUNOS"
+        ;;
+    *-cygwin*)
+        CFLAGS="$CFLAGS -D__CYGWIN -I /usr/include/ncurses -I /usr/lib/WpdPack/Include -I /usr/include/SctpDrv"
+        CPPFLAGS="$CPPFLAGS -D__CYGWIN -I /usr/include/ncurses -I /usr/lib/WpdPack/Include -I /usr/include/SctpDrv"
         LDFLAGS="$LDFLAGS -L /usr/lib/WpdPack/Lib -L /usr/lib/SctpDrv"
-		;;
-	*-tru64*)
-		CFLAGS="$CFLAGS -D__OSF1"
-		CPPFLAGS="$CPPFLAGS -D__OSF1"
-		;;
+        ;;
+    *-tru64*)
+        CFLAGS="$CFLAGS -D__OSF1"
+        CPPFLAGS="$CPPFLAGS -D__OSF1"
+        ;;
 esac
 
 # ==================== checks for libraries =============================
 AC_CHECK_LIB(curses,initscr,,[AC_MSG_ERROR([ncurses library missing])])
 AC_CHECK_LIB(pthread, pthread_mutex_init, THREAD_LIBS="-lpthread",
-               AC_MSG_ERROR(pthread library needed!))
+    AC_MSG_ERROR(pthread library needed!))
 
 # For Linux and SunOS
 AC_SEARCH_LIBS([dlopen], [dl])
@@ -120,36 +119,36 @@ AC_SEARCH_LIBS([shutdown], [socket])
 
 # Conditional build with OpenSSL
 if test "$openssl" = 'yes'; then
-	AC_CHECK_HEADERS([openssl/md5.h],,[AC_MSG_ERROR([<openssl/md5.h> header missing])])
-	AC_CHECK_HEADERS([openssl/bio.h],,[AC_MSG_ERROR([<openssl/bio.h> header missing])])
-	AC_CHECK_HEADERS([openssl/err.h],,[AC_MSG_ERROR([<openssl/err.h> header missing])])
-	AC_CHECK_HEADERS([openssl/rand.h],,[AC_MSG_ERROR([<openssl/rand.h> header missing])])
-	AC_CHECK_HEADERS([openssl/ssl.h],,[AC_MSG_ERROR([<openssl/ssl.h> header missing])])
-	AC_CHECK_HEADERS([openssl/x509v3.h],,[AC_MSG_ERROR([<openssl/x509v3.h> header missing])])
-	AC_CHECK_LIB([ssl], [SSL_library_init],,[AC_MSG_ERROR([ssl library missing])])
-	AC_CHECK_LIB([crypto], [CRYPTO_num_locks],,[AC_MSG_ERROR([crypto library missing])])
+    AC_CHECK_HEADERS([openssl/md5.h],,[AC_MSG_ERROR([<openssl/md5.h> header missing])])
+    AC_CHECK_HEADERS([openssl/bio.h],,[AC_MSG_ERROR([<openssl/bio.h> header missing])])
+    AC_CHECK_HEADERS([openssl/err.h],,[AC_MSG_ERROR([<openssl/err.h> header missing])])
+    AC_CHECK_HEADERS([openssl/rand.h],,[AC_MSG_ERROR([<openssl/rand.h> header missing])])
+    AC_CHECK_HEADERS([openssl/ssl.h],,[AC_MSG_ERROR([<openssl/ssl.h> header missing])])
+    AC_CHECK_HEADERS([openssl/x509v3.h],,[AC_MSG_ERROR([<openssl/x509v3.h> header missing])])
+    AC_CHECK_LIB([ssl], [SSL_library_init],,[AC_MSG_ERROR([ssl library missing])])
+    AC_CHECK_LIB([crypto], [CRYPTO_num_locks],,[AC_MSG_ERROR([crypto library missing])])
 fi
 # For Makefile.am
 AM_CONDITIONAL(HAVE_OPENSSL, test "$openssl" = "yes")
 
 # Conditional build with SCTP
 if test "$sctp" = 'yes'; then
-	AC_CHECK_HEADERS([netinet/sctp.h],,[AC_MSG_WARN([<netinet/sctp.h> header missing, but this is acceptable on Mac OS X Lion])])
-	AC_SEARCH_LIBS([sctp_send],[sctp sctpsp],,[AC_MSG_ERROR([SCTP library missing])])
-	AC_SEARCH_LIBS([sctp_freepaddrs],[sctp sctpsp],,[AC_MSG_ERROR([SCTP library missing])])
-	AC_SEARCH_LIBS([sctp_bindx],[sctp sctpsp],,[AC_MSG_ERROR([SCTP library missing])])
-	AC_SEARCH_LIBS([sctp_recvmsg],[sctp sctpsp],,[AC_MSG_ERROR([SCTP library missing])])
+    AC_CHECK_HEADERS([netinet/sctp.h],,[AC_MSG_WARN([<netinet/sctp.h> header missing, but this is acceptable on Mac OS X Lion])])
+    AC_SEARCH_LIBS([sctp_send],[sctp sctpsp],,[AC_MSG_ERROR([SCTP library missing])])
+    AC_SEARCH_LIBS([sctp_freepaddrs],[sctp sctpsp],,[AC_MSG_ERROR([SCTP library missing])])
+    AC_SEARCH_LIBS([sctp_bindx],[sctp sctpsp],,[AC_MSG_ERROR([SCTP library missing])])
+    AC_SEARCH_LIBS([sctp_recvmsg],[sctp sctpsp],,[AC_MSG_ERROR([SCTP library missing])])
 fi
 # For Makefile.am
 AM_CONDITIONAL(HAVE_SCTP, test "$sctp" = "yes")
 
 # Conditional build with pcap
 if test "$pcap" = 'yes'; then
-	AC_CHECK_HEADERS([pcap.h],,[AC_MSG_ERROR([<pcap.h> header missing])])
-	AC_SEARCH_LIBS([pcap_open_offline],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
-	AC_SEARCH_LIBS([pcap_next],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
-	AC_SEARCH_LIBS([pcap_close],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
-	AC_CHECK_LIB([pcap],[pcap_next_ex],AC_DEFINE([HAVE_PCAP_NEXT_EX],[1],[Define to 1 if libpcap has the pcap_next_ex function.]))
+    AC_CHECK_HEADERS([pcap.h],,[AC_MSG_ERROR([<pcap.h> header missing])])
+    AC_SEARCH_LIBS([pcap_open_offline],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
+    AC_SEARCH_LIBS([pcap_next],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
+    AC_SEARCH_LIBS([pcap_close],[pcap wpcap],,[AC_MSG_ERROR([pcap library missing])])
+    AC_CHECK_LIB([pcap],[pcap_next_ex],AC_DEFINE([HAVE_PCAP_NEXT_EX],[1],[Define to 1 if libpcap has the pcap_next_ex function.]))
 fi
 # For Makefile.am
 AM_CONDITIONAL(HAVE_PCAP, test "$pcap" = "yes")
@@ -158,21 +157,21 @@ AM_CONDITIONAL(HAVE_RTP, test "$rtp" = "yes")
 
 # Conditional build with pcap
 if test "$gsl" = 'yes'; then
-	AC_CHECK_HEADERS([gsl/gsl_randist.h],,[AC_MSG_ERROR([<gsl/gsl_randist.h> header missing])])
-	AC_CHECK_HEADERS([gsl/gsl_rng.h],,[AC_MSG_ERROR([<gsl/gsl_rng.h> header missing])])
-	AC_CHECK_HEADERS([gsl/gsl_cdf.h],,[AC_MSG_ERROR([<gsl/gsl_cdf.h> header missing])])
-	AC_CHECK_LIB([m],[cos])
-	AC_CHECK_LIB([gslcblas], [cblas_dgemm])
-	AC_CHECK_LIB([gsl], [gsl_rng_alloc],
-		     [
-		      GSL_CFLAGS=`pkg-config gsl --cflags`
-		      GSL_CXXFLAGS=`pkg-config gsl --cflags`
-		      GSL_LIBS=`pkg-config gsl --libs`
-		      AC_SUBST([GSL_CFLAGS])
-		      AC_SUBST([GSL_CXXFLAGS])
-		      AC_SUBST([GSL_LIBS])
-		      ]
-		     ,[AC_MSG_ERROR([gsl library missing])])
+    AC_CHECK_HEADERS([gsl/gsl_randist.h],,[AC_MSG_ERROR([<gsl/gsl_randist.h> header missing])])
+    AC_CHECK_HEADERS([gsl/gsl_rng.h],,[AC_MSG_ERROR([<gsl/gsl_rng.h> header missing])])
+    AC_CHECK_HEADERS([gsl/gsl_cdf.h],,[AC_MSG_ERROR([<gsl/gsl_cdf.h> header missing])])
+    AC_CHECK_LIB([m],[cos])
+    AC_CHECK_LIB([gslcblas], [cblas_dgemm])
+    AC_CHECK_LIB([gsl], [gsl_rng_alloc],
+                 [
+                  GSL_CFLAGS=`pkg-config gsl --cflags`
+                  GSL_CXXFLAGS=`pkg-config gsl --cflags`
+                  GSL_LIBS=`pkg-config gsl --libs`
+                  AC_SUBST([GSL_CFLAGS])
+                  AC_SUBST([GSL_CXXFLAGS])
+                  AC_SUBST([GSL_LIBS])
+                  ]
+                 ,[AC_MSG_ERROR([gsl library missing])])
 fi
 # For Makefile.am
 AM_CONDITIONAL(HAVE_GSL, test "$gsl" = "yes")


### PR DESCRIPTION
One patch applies consistent formatting, the other one fixes the `make dist` target.

Now you can run `make distcheck` to produce a tarball suitable for distribution.