### PR TITLE
Fix invalid authentication response calculation

### DIFF
--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -264,7 +264,6 @@ int createAuthResponseMD5(const char *user,
     unsigned char ha1_hex[HASH_HEX_SIZE+1], ha2_hex[HASH_HEX_SIZE+1];
     char tmp[MAX_HEADER_LEN];
     md5_state_t Md5Ctx;
-    const char authint[] = "auth-int";
 
     // Load in A1
     md5_init(&Md5Ctx);
@@ -311,7 +310,7 @@ int createAuthResponseMD5(const char *user,
         md5_append(&Md5Ctx, (md5_byte_t *) ":", 1);
         md5_append(&Md5Ctx, (md5_byte_t *) cnonce, strlen(cnonce));
         md5_append(&Md5Ctx, (md5_byte_t *) ":", 1);
-        md5_append(&Md5Ctx, (md5_byte_t *) authint, strlen(authint));
+        md5_append(&Md5Ctx, (md5_byte_t *) authtype, strlen(authtype));
     }
     md5_append(&Md5Ctx, (md5_byte_t *) ":", 1);
     md5_append(&Md5Ctx, (md5_byte_t *) &ha2_hex, HASH_HEX_SIZE);


### PR DESCRIPTION
The digest calculation when "qop" is given follows from:

    HA1=MD5(username:realm:password)
    HA2=MD5(method:digestURI)
    response=MD5(HA1:nonce:nonceCount:clientNonce:qop:HA2)

When qop is not given, the response is:

    response=MD5(HA1:nonce:HA2)

Currently the qop parameter is hard-coded to "auth-int" which fails to
compute the correct hash for qop=auth. Fix this by using the correct
authentication type instead.

References:

 - https://tools.ietf.org/html/rfc3261#section-22.4
 - https://en.wikipedia.org/wiki/Digest_access_authentication#Overview

Fixes https://github.com/SIPp/sipp/issues/87