### PR TITLE
Replace xp_replace with more correct html escape handling

### DIFF
--- a/include/xp_parser.h
+++ b/include/xp_parser.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-int   xp_replace(const char *source, char *dest, const char *search, const char *replace);
+int   xp_unescape(const char *source, char *dest);
 int   xp_set_xml_buffer_from_string(const char *str);
 int   xp_set_xml_buffer_from_file(const char *filename);
 char *xp_open_element(int index);

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -1349,7 +1349,6 @@ void scenario::parseAction(CActions *actions)
     char *        actionElem;
     unsigned int recvScenarioLen = 0;
     char *        currentRegExp = NULL;
-    char *        buffer = NULL;
     char **       currentTabVarName = NULL;
     int           currentNbVarNames;
     char * ptr;
@@ -1365,11 +1364,7 @@ void scenario::parseAction(CActions *actions)
             if(currentRegExp != NULL)
                 delete[] currentRegExp;
             currentRegExp = new char[strlen(ptr)+1];
-            buffer = new char[strlen(ptr)+1];
-            xp_replace(ptr, buffer, "&lt;", "<");
-            xp_replace(buffer, currentRegExp, "&gt;", ">");
-            if(buffer != NULL)
-                delete[] buffer;
+            xp_unescape(ptr, currentRegExp);
             tmpAction->setActionType(CAction::E_AT_ASSIGN_FROM_REGEXP);
 
             // warning - although these are detected for both msg and hdr


### PR DESCRIPTION
One of our internal tools started spits out sipp scripts containing the `&quot;` html escape which sipp is not capable of handling. This patch set replaces the `xp_replace` with temporary buffer with a new mechanism which is one step closer to a proper html escape parser. The new code path only handles a few more sequences (`&amp;`, `&gt;`, `&lt;`, and `&quot;`) but is a good starting place for a better mechanism.

Another option could be to pull out the xp_parser.c file and replace it with a better, standard, off-the-shelf xml parser.

I've extensively tested this personally, but not sure how to trigger the `xp_parser_ut.cpp` code.