### PR TITLE
A stab at fixing #34: don't add CRLF to just any CDATA

### DIFF
--- a/regress/github-#0034/run
+++ b/regress/github-#0034/run
@@ -1,0 +1,38 @@
+#!/bin/sh
+# This regression test is a part of SIPp.
+# Author: Walter Doekes, OSSO B.V., 2015
+. "`dirname "$0"`/../functions"; init
+
+# Test that the NOTIFY sent contains exactly 4 bytes of body and not
+# an additional CRLF pair.
+sippbg -m 1 -sf uas.xml -i 127.0.0.1 -p 5070 -trace_msg -message_file from-uac.log
+sippbg -m 1 -sf uac.xml -i 127.0.0.1 127.0.0.1:5070 -trace_msg -message_file from-uas.log
+job2=$!
+
+# This should surely finish quickly.
+if kill -0 $job2 2>/dev/null; then
+    fail
+fi
+
+# Grep the log file for 0x01 0x02 0x03 0x04 without any trailing CRLF.
+if cat -A from-uac.log | tr -d '\n' | grep -qF '$Content-Length: 4^M$^M$^A^B^C^D$----'; then
+    true  # pass
+else
+    fail "unexpected CRLFs in SIP body"
+fi
+
+# Grep the log file for X-Last-Header and check that it has trailing
+# CRLF CRLF (1).
+if cat -A from-uas.log | tr -d '\n' | grep -qF '$X-Last-Header: missing-crlf^M$^M$$'; then
+    true  # pass
+else
+    fail "missing CRLFs in SIP header"
+fi
+
+# Grep the log file for X-Last-Header and check that it has trailing
+# CRLF CRLF (2).
+if cat -A from-uac.log | tr -d '\n' | grep -qF '$X-Last-Header: an-extra-crlf^M$^M$$'; then
+    ok
+else
+    fail "too many CRLFs in SIP header"
+fi

--- a/regress/github-#0034/uac.xml
+++ b/regress/github-#0034/uac.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <!-- Observe how the CDATA is cut short (no trailing linefeeds).
+       Here we *don't* want SIPp to add any CRLF to packet body. -->
+  <send retrans="500">
+    <![CDATA[
+
+      NOTIFY sip:127.0.0.1:5070 SIP/2.0
+      Via: SIP/2.0/UDP 127.0.0.1:5070;branch=[branch]
+      From: sip:127.0.0.1:5060;tag=TAG
+      To: sip:127.0.0.1:5070
+      Call-ID: [call_id]
+      CSeq: 1 NOTIFY
+      Contact: sip:sipp@127.0.0.1:5060
+      Max-Forwards: 70
+      Event: telephone-event
+      Content-Type: audio/telephone-event
+      Content-Length: 4
+
+      \x01\x02\x03\x04]]>
+  </send>
+
+  <recv response="200"/>
+
+  <!-- Here, some excess CRLFs. -->
+  <send retrans="500">
+    <![CDATA[
+
+      NOTIFY sip:127.0.0.1:5070 SIP/2.0
+      Via: SIP/2.0/UDP 127.0.0.1:5070;branch=[branch]
+      From: sip:127.0.0.1:5060;tag=TAG
+      To: sip:127.0.0.1:5070
+      Call-ID: [call_id]
+      CSeq: 2 NOTIFY
+      Contact: sip:sipp@127.0.0.1:5060
+      Max-Forwards: 70
+      Event: telephone-event
+      Content-Type: audio/telephone-event
+      Content-Length: 0
+      X-Last-Header: an-extra-crlf
+
+
+    ]]>
+  </send>
+
+  <recv response="200"/>
+</scenario>

--- a/regress/github-#0034/uas.xml
+++ b/regress/github-#0034/uas.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <recv request="NOTIFY"/>
+
+  <!-- Observe how the CDATA is cut short (no trailing linefeeds).
+       Here we *want* SIPp to add 2x CRLF. -->
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=TAG
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@127.0.0.1:5070
+      Max-Forwards: 70
+      X-Last-Header: missing-crlf]]></send>
+
+  <recv request="NOTIFY"/>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=TAG
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@127.0.0.1:5070
+      Max-Forwards: 70
+
+    ]]>
+
+  <timewait milliseconds="500"/>
+</scenario>

--- a/regress/runtests
+++ b/regress/runtests
@@ -9,6 +9,8 @@ cd `dirname "$0"`
 find . -name '*.log' | xargs --no-run-if-empty -d\\n rm -v
 echo
 
+# Export custom location SIPP binary if supplied.
+export SIPP
 # Set flag that we want verbose exit codes.
 export VERBOSE_EXITSTATUS=1
 


### PR DESCRIPTION
Not sure why the removed_crlf was only use in the `<send>` code and not the `<sendCmd>`.

Rob, do you see anything wrong with this?