### PR TITLE
Improve SDP parsing to accept \n as line terminator

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -148,7 +148,7 @@ uint32_t get_remote_ip_media(char *msg)
         /* Can't find what we're looking at -> return no address */
         return INADDR_NONE;
     }
-    begin += sizeof("c=IN IP4 ") - 1;
+    begin += sizeof(pattern) - 1;
     end = find_sdp_eol(begin);
     if (!end) {
         free(my_msg);
@@ -185,7 +185,7 @@ uint8_t get_remote_ipv6_media(char *msg, struct in6_addr *addr)
         /* Can't find what we're looking at -> return no address */
         return 0;
     }
-    begin += sizeof("c=IN IP6 ") - 1;
+    begin += sizeof(pattern) - 1;
     end = find_sdp_eol(begin);
     if (!end) {
         free(my_msg);

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <cstring>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <assert.h>
@@ -119,6 +120,12 @@ unsigned int call::wake()
     return wake;
 }
 
+static char* find_sdp_eol(char* line)
+{
+    char* end = &line[strcspn(line, "\r\n")];
+    return end[0] == '\0' ? NULL : end;
+}
+
 #ifdef PCAPPLAY
 /******* Media information management *************************/
 /*
@@ -142,7 +149,7 @@ uint32_t get_remote_ip_media(char *msg)
         return INADDR_NONE;
     }
     begin += sizeof("c=IN IP4 ") - 1;
-    end = strstr(begin, "\r\n");
+    end = find_sdp_eol(begin);
     if (!end) {
         free(my_msg);
         return INADDR_NONE;
@@ -179,7 +186,7 @@ uint8_t get_remote_ipv6_media(char *msg, struct in6_addr *addr)
         return 0;
     }
     begin += sizeof("c=IN IP6 ") - 1;
-    end = strstr(begin, "\r\n");
+    end = find_sdp_eol(begin);
     if (!end) {
         free(my_msg);
         return 0;
@@ -230,7 +237,7 @@ uint16_t get_remote_port_media(const char *msg, enum media_ptn pattype)
         return 0;
     }
     begin += strlen(pattern);
-    end = strstr(begin, "\r\n");
+    end = find_sdp_eol(begin);
     if (!end) {
         free(my_msg);
         ERROR("get_remote_port_media: no CRLF found");


### PR DESCRIPTION
RFC 4566 says parers SHOULD accept both single CR and LF characters as line terminators:

> The sequence CRLF (0x0d0a) is used to end a record, although parsers SHOULD be tolerant and also accept records terminated with a single newline character.