### PR TITLE
Fix potential double free after sendCmdBuffer

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -4093,6 +4093,7 @@ bool call::automaticResponseMode(T_AutoMode P_case, char * P_recv)
                 res = sendCmdBuffer(createSendingMessage(get_default_message("3pcc_abort"), -1));
                 if (res) {
                     WARNING("sendCmdBuffer returned %d", res);
+                    return false;
                 }
             }
             computeStat(CStat::E_CALL_FAILED);
@@ -4130,6 +4131,7 @@ bool call::automaticResponseMode(T_AutoMode P_case, char * P_recv)
                 res = sendCmdBuffer(createSendingMessage(get_default_message("3pcc_abort"), -1));
                 if (res) {
                     WARNING("sendCmdBuffer returned %d", res);
+                    return false;
                 }
             }
 
@@ -4165,6 +4167,7 @@ bool call::automaticResponseMode(T_AutoMode P_case, char * P_recv)
                 res = sendCmdBuffer(createSendingMessage(get_default_message("3pcc_abort"), -1));
                 if (res) {
                     WARNING("sendCmdBuffer returned %d", res);
+                    return false;
                 }
             }
 


### PR DESCRIPTION
The stupid `delete this;` error handling insider sendCmdBuffer sucks. We need to bail anytime that function returns a failure or we trigger either double frees or use-after-free bugs.

Caught by clang-analyzer.

I might revisit this to see if I can tackle the memory allocation madness since this isn't really what I'd consider maintainable.