### PR TITLE
Disable SDP parsing when you use ignoresdp="true".

### DIFF
--- a/include/scenario.hpp
+++ b/include/scenario.hpp
@@ -105,6 +105,7 @@ public:
     int            counter;
     double         lost;
     int            crlf;
+    bool           ignoresdp;
     bool           hide;
     char *         display_str;
     int            next;

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -2939,9 +2939,12 @@ bool call::process_incoming(char* msg, struct sockaddr_storage *src)
               strlen(msg), id, hash(msg), msg);
 
     setRunning();
+    message *curmsg = call_scenario->messages[msg_index];
 
     /* Ignore the messages received during a pause if -pause_msg_ign is set */
-    if (call_scenario->messages[msg_index]->M_type == MSG_TYPE_PAUSE && pause_msg_ign) return true;
+    if (curmsg->M_type == MSG_TYPE_PAUSE && pause_msg_ign) {
+        return true;
+    }
 
     /* Get our destination if we have none. */
     if (call_peer.ss_family == AF_UNSPEC && src) {
@@ -2949,8 +2952,8 @@ bool call::process_incoming(char* msg, struct sockaddr_storage *src)
     }
 
     /* Authorize nop as a first command, even in server mode */
-    if ((msg_index == 0) && (call_scenario->messages[msg_index]->M_type == MSG_TYPE_NOP)) {
-        queue_up (msg);
+    if (msg_index == 0 && curmsg->M_type == MSG_TYPE_NOP) {
+        queue_up(msg);
         paused_until = 0;
         return run();
     }
@@ -3016,8 +3019,8 @@ bool call::process_incoming(char* msg, struct sockaddr_storage *src)
 
 #ifdef RTP_STREAM
     /* Check if message has a SDP in it; and extract media information. */
-    if (!strcmp(get_header_content(msg, (char*)"Content-Type:"),"application/sdp") &&
-        (hasMedia == 1)) {
+    if (!strcmp(get_header_content(msg, "Content-Type:"), "application/sdp") &&
+            hasMedia == 1 && !curmsg->ignoresdp) {
         extract_rtp_remote_addr(msg);
     }
 #endif
@@ -3037,7 +3040,7 @@ bool call::process_incoming(char* msg, struct sockaddr_storage *src)
                 return false; // Call aborted by unexpected message handling
             }
 #ifdef PCAPPLAY
-        } else if ((hasMedia == 1) && *(strstr(msg, "\r\n\r\n") + 4) != '\0') {
+        } else if (hasMedia == 1 && !curmsg->ignoresdp && *(strstr(msg, "\r\n\r\n") + 4) != '\0') {
             /* Get media info if we find something like an SDP */
             get_remote_media_addr(msg);
 #endif
@@ -3075,8 +3078,9 @@ bool call::process_incoming(char* msg, struct sockaddr_storage *src)
             if (((strncmp(request, "INVITE", 6) == 0)
                     || (strncmp(request, "ACK", 3) == 0)
                     || (strncmp(request, "PRACK", 5) == 0))
-                    && (hasMedia == 1))
+                    && hasMedia == 1 && !curmsg->ignoresdp) {
                 get_remote_media_addr(msg);
+            }
 #endif
 
             reply_code = 0;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -65,6 +65,7 @@ message::message(int index, const char *desc)
     repeat_rtd = 0;
     lost = -1;
     crlf = 0;
+    ignoresdp = false;
     hide = 0;
     display_str = NULL; // free on exit
     test = -1;
@@ -1714,6 +1715,10 @@ void scenario::getCommonAttributes(message *message)
         message -> crlf = 1;
     }
 
+    if ((ptr = xp_get_value("ignoresdp"))) {
+        message->ignoresdp = get_bool(ptr, "ignoresdp");
+    }
+
     if (xp_get_value("hiderest")) {
         hidedefault = xp_get_bool("hiderest", "hiderest");
     }
@@ -2055,6 +2060,9 @@ const char * default_scenario [] = {
     "  <!-- By adding rrs=\"true\" (Record Route Sets), the route sets         -->\n"
     "  <!-- are saved and used for following messages sent. Useful to test   -->\n"
     "  <!-- against stateful SIP proxies/B2BUAs.                             -->\n"
+    "  <!-- Adding ignoresdp=\"true\" here would ignore the SDP data: that     -->\n"
+    "  <!-- can be useful if you want to reject reINVITEs and keep the       -->\n"
+    "  <!-- media stream flowing.                                            -->\n"
     "  <recv request=\"INVITE\" crlf=\"true\">\n"
     "  </recv>\n"
     "\n"


### PR DESCRIPTION
Suggested by @kovacsbalu. This will allow you to keep your media stream
going while rejecting the SDP from a reINVITE.

This obsoletes #97.

I did not test this, but it has better code style and better documentation than the original pull request.

I'm not entirely sure about:
- adding more booleans to the message class
- the naming of ignoresdp
