### PR TITLE
Change pcap search logic so we prefer files found next to the scenario file.

### DIFF
--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -28,7 +28,6 @@ extern bool   useLogf                             _DEFVAL(0);
 extern bool   dumpInFile                          _DEFVAL(0);
 extern bool   dumpInRtt                           _DEFVAL(0);
 extern bool   useCountf                           _DEFVAL(0);
-extern char * scenario_file;
 extern char * slave_cfg_file;
 
 extern unsigned long long max_log_size            _DEFVAL(0);

--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -4,8 +4,7 @@
 /************************** Trace Files ***********************/
 
 #include <time.h>
-
-#define MAX_PATH                   250
+#include "sipp.hpp"
 
 #ifdef GLOBALS_FULL_DEFINITION
 #define extern

--- a/include/screen.hpp
+++ b/include/screen.hpp
@@ -39,6 +39,8 @@ extern "C" {
 }
 #endif
 
+#define MAX_PATH                   250
+
 #define EXIT_TEST_OK               0
 #define EXIT_TEST_FAILED           1
 #define EXIT_TEST_RES_INTERNAL     97

--- a/include/send_packets.h
+++ b/include/send_packets.h
@@ -120,8 +120,8 @@ typedef struct {
 extern "C"
 {
 #endif
-    int parse_play_args (char *, pcap_pkts *);
-    int send_packets (play_args_t *);
+    int parse_play_args(const char*, pcap_pkts*);
+    int send_packets(play_args_t*);
 #ifdef __cplusplus
 }
 #endif

--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -317,8 +317,10 @@ extern SSL              * twinSipp_ssl;
 extern const char       * tls_cert_name           _DEFVAL(DEFAULT_TLS_CERT);
 extern const char       * tls_key_name            _DEFVAL(DEFAULT_TLS_KEY);
 extern const char       * tls_crl_name            _DEFVAL(DEFAULT_TLS_CRL);
-
 #endif
+
+extern char*              scenario_file           _DEFVAL(NULL);
+extern char*              scenario_path           _DEFVAL(NULL);
 
 // extern field file management
 typedef std::map<string, FileContents *> file_map;

--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -135,8 +135,6 @@
 #define MAX_SCHED_LOOPS_PER_CYCLE  1000
 #define NB_UPDATE_PER_CYCLE        1
 
-#define MAX_PATH                   250
-
 #define MAX_PEER_SIZE              4096  /* 3pcc extended mode: max size of peer names */
 #define MAX_LOCAL_TWIN_SOCKETS     10    /*3pcc extended mode:max number of peers from which
 cmd messages are received */

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -53,8 +53,6 @@
 #include "prepare_pcap.h"
 #include "screen.hpp"
 
-#define MAX_PATH 250
-
 extern char* scenario_path;
 extern volatile unsigned long rtp_pckts_pcap;
 extern volatile unsigned long rtp_bytes_pcap;

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -53,6 +53,9 @@
 #include "prepare_pcap.h"
 #include "screen.hpp"
 
+#define MAX_PATH 250
+
+extern char* scenario_path;
 extern volatile unsigned long rtp_pckts_pcap;
 extern volatile unsigned long rtp_bytes_pcap;
 extern int media_ip_is_ipv6;
@@ -86,11 +89,29 @@ float2timer (float time, struct timeval *tvp)
     tvp->tv_usec = n * 100000;
 }
 
-/* buffer should be "file_name" */
-int
-parse_play_args (char *buffer, pcap_pkts *pkts)
+static char* find_file(const char* filename)
 {
-    pkts->file = strdup (buffer);
+    if (filename[0] == '/' || !scenario_path) {
+        return strdup(filename);
+    }
+
+    char *fullpath = malloc(MAX_PATH);
+    snprintf(fullpath, MAX_PATH, "%s/%s", scenario_path, filename);
+
+    if (access(fullpath, R_OK) < 0) {
+        free(fullpath);
+        WARNING("SIPp now prefers looking for pcap files next to the scenario. "
+                "%s couldn't be found next to the scenario, falling back to "
+                "using the current working directory", filename);
+        return strdup(filename);
+    }
+
+    return fullpath;
+}
+
+int parse_play_args(const char* filename, pcap_pkts* pkts)
+{
+    pkts->file = find_file(filename);
     prepare_pkts(pkts->file, pkts);
     return 1;
 }


### PR DESCRIPTION
One of the breaking changes with the Sangoma SIPp fork is that we changed the pcap search logic to prefer looking next to the scenario file. This made organizing a large collection of different sipp scenarios considerably simpler.

This is a more thorough patch to the one we have internally, refactoring some other logic as well. I was going to initially prefer checking the current working directory and then, failing finding a pcap there, search next to the scenario. While discussing this change with @wdoekes, he suggested that the current behaviour could actually be considered a bug, which prompted to instead do the reverse, prefer the file next to the scenario instead. This probably makes way more sense and what would be expected anyways.

So, assuming we go with this approach, this patch also adds some additional warning messages to help with the migration:

- Warn if the pcap can't be found next to the scenario that we'll fallback to assuming the file is in the current working directory
- Warn if the pcap happens to be found in both places that now the one next to the scenario will be used.

Catch: the second warning can have false positives: when we provide a full path to the scenario which also happens to be in the current working directory as well. Either I should check if `scenario_path == getcwd()` or just drop the second warning. I'm not convinced its a common enough occurrence.