### PR TITLE
Automate version info using git describe

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,8 @@
 # ======================== initialization ===============================
 
-AC_INIT([SIPp], [3.5.0-rc1], [sipp-users@lists.sourceforge.net], [sipp])
+AC_INIT([SIPp],
+        [m4_esyscmd_s([git describe --tags --always])],
+        [sipp-users@lists.sourceforge.net], [sipp])
 
 # Load non-standard m4 files from ./m4/*.m4.
 # AC_CONFIG_MACRO_DIR([m4]) does not work on pre-1.13 aclocal, so we

--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -104,8 +104,6 @@
 
 /************************** Constants **************************/
 
-#define SIPP_VERSION               "3.5.0-rc1" /* don't forget to update configure.ac */
-
 #define T_UDP                      0
 #define T_TCP                      1
 #define T_TLS                      2

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -53,6 +53,7 @@
 #include "sipp.hpp"
 #include "auth.hpp"
 #include "deadcall.hpp"
+#include "config.h"
 
 #define callDebug(args...) do { if (useCallDebugf) { _callDebug( args ); } } while (0)
 
@@ -2314,7 +2315,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             dest += snprintf(dest, left, "%d", userId);
             break;
         case E_Message_SippVersion:
-            dest += snprintf(dest, left, "%s", SIPP_VERSION);
+            dest += snprintf(dest, left, "%s", VERSION);
             break;
         case E_Message_Variable: {
             int varId = comp->varId;

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -44,6 +44,7 @@
 #include "socket.hpp"
 #include "logger.hpp"
 #include "assert.h"
+#include "config.h"
 
 extern struct sipp_socket *ctrl_socket;
 extern struct sipp_socket *stdin_socket;
@@ -1377,7 +1378,7 @@ int main(int argc, char *argv[])
             case SIPP_OPTION_VERSION:
                 printf("\n %s.\n\n",
                        /* SIPp v1.2.3-TLS-PCAP built YMD, HMS */
-                       "SIPp v" SIPP_VERSION
+                       "SIPp " VERSION
 #ifdef _USE_OPENSSL
                        "-TLS"
 #endif


### PR DESCRIPTION
This pulls out the `SIPP_VERSION` macro to favour of the `VERSION` macro provided by `config.h`. This is something we probably want in general so we can do away with the "don't forget to update configure.ac" because we really don't have to remember to update both.

The `m4_esyscmd_s([git describe --tags --always --dirty])` trick lets us use git to provide the version info. After compiling sipp with this change set, I now get the much more descriptive:

```
$ sipp -v
 SIPp v3.5.0-rc1-52-ga3a53de-dirty-TLS-SCTP-PCAP-RTPSTREAM built May 30 2015, 23:44:00.
```

Two things to note:

1. `--dirty` might not actually be desirable, as I'm pretty sure all builds will end up dirty. Building sipp marks the gtest submodule as dirty and thus the sipp parent repo. The first build should be clean but subsequent builds will be dirty.
2. `--tags` is there because versions have been marked with regular tags. You guys should seriously consider switching to annotated tags for versioning. At the very least you'll leave users with a record of *who* made a release (and they can be signed).