### PR TITLE
Don't abort the sipp run on missing To header. Only fail the call.

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -2955,6 +2955,11 @@ bool call::process_incoming(char* msg, struct sockaddr_storage *src)
     responsecseqmethod[0] = '\0';
     txn[0] = '\0';
 
+    /* Check that we have a To:-header */
+    if (!get_header(msg, "To:", false)[0] && !process_unexpected(msg)) {
+        return false;
+    }
+
     if ((transport == T_UDP) && (retrans_enabled)) {
         /* Detects retransmissions from peer and retransmit the
          * message which was sent just after this one was received */

--- a/src/sip_parser.cpp
+++ b/src/sip_parser.cpp
@@ -80,7 +80,8 @@ char * get_peer_tag(const char *msg)
     /* Find start of header */
     to_hdr = internal_find_header(msg, "To", "t", true);
     if (!to_hdr) {
-        ERROR("No valid To: header in reply");
+        WARNING("No valid To: header in reply");
+        return NULL;
     }
 
     /* Skip past display-name */


### PR DESCRIPTION
Fixes #152.