### PR TITLE
Fix a few memory leaks at shutdown.

### DIFF
--- a/include/screen.hpp
+++ b/include/screen.hpp
@@ -49,7 +49,7 @@ extern "C" {
 #define EXIT_FATAL_ERROR           -1
 #define EXIT_BIND_ERROR            -2
 
-void screen_set_exename(char * exe_name);
+void screen_set_exename(const char* exe_name);
 void screen_init();
 void screen_clear();
 int  screen_readkey();

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -49,8 +49,6 @@ struct sipp_socket *sipp_allocate_socket(bool use_ipv6, int transport, int fd, i
 void setup_ctrl_socket();
 void setup_stdin_socket();
 
-char * get_inet_address(struct sockaddr_storage * addr);
-
 int handle_ctrl_socket();
 void handle_stdin_socket();
 void process_message(struct sipp_socket *socket, char *msg, ssize_t msg_size, struct sockaddr_storage *src);

--- a/regress/github-#0156/run
+++ b/regress/github-#0156/run
@@ -1,0 +1,28 @@
+#!/bin/sh
+# This regression test is a part of SIPp.
+# Author: Walter Doekes, OSSO B.V., 2015
+. "`dirname "$0"`/../functions"; init
+
+# Valgrind on UAS.
+valgrind --xml=yes --xml-file=uas.log --partial-loads-ok=yes \
+    --show-leak-kinds=all --leak-check=full `get_sipp` -nostdin -m 10 -sn uas \
+    >/dev/null 2>&1 &
+uaspid=$!
+sleep 1
+
+# Valgrind on UAC.
+valgrind --xml=yes --xml-file=uac.log --partial-loads-ok=yes \
+    --show-leak-kinds=all --leak-check=full `get_sipp` -nostdin -m 10 -sn uac \
+    127.0.0.1 >/dev/null 2>&1 &
+uacpid=$!
+
+wait $uaspid
+test $? -ne 0 && fail "UAS returned non-zero"
+
+wait $uacpid
+test $? -ne 0 && fail "UAC returned non-zero"
+
+grep -q '<error>' uas.log && fail "valgrind reported leaks in UAS"
+grep -q '<error>' uac.log && fail "valgrind reported leaks in UAC"
+
+ok

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -915,16 +915,15 @@ bool call::connect_socket_if_needed()
                         NULL,
                         &hints,
                         &h);
-            memcpy(&saddr,
-                   h->ai_addr,
-                   SOCK_ADDR_SIZE(
-                       _RCAST(struct sockaddr_storage *,h->ai_addr)));
+            memcpy(&saddr, h->ai_addr,
+                   SOCK_ADDR_SIZE(_RCAST(struct sockaddr_storage*, h->ai_addr)));
 
             if (use_ipv6) {
-                (_RCAST(struct sockaddr_in6 *, &saddr))->sin6_port = htons(local_port);
+                (_RCAST(struct sockaddr_in6*, &saddr))->sin6_port = htons(local_port);
             } else {
-                (_RCAST(struct sockaddr_in *, &saddr))->sin_port = htons(local_port);
+                (_RCAST(struct sockaddr_in*, &saddr))->sin_port = htons(local_port);
             }
+            freeaddrinfo(h);
         }
 
         if (sipp_bind_socket(call_socket, &saddr, &call_port)) {
@@ -3661,13 +3660,17 @@ call::T_ActionResult call::executeAction(char * msg, message *curmsg)
             if (_RCAST(struct sockaddr_storage *, local_addr->ai_addr)->ss_family != call_peer.ss_family) {
                 ERROR("Can not switch between IPv4 and IPV6 using setdest!");
             }
-            memcpy(&call_peer, local_addr->ai_addr, SOCK_ADDR_SIZE(_RCAST(struct sockaddr_storage *,local_addr->ai_addr)));
+            memcpy(&call_peer, local_addr->ai_addr,
+                   SOCK_ADDR_SIZE(_RCAST(struct sockaddr_storage*, local_addr->ai_addr)));
+            freeaddrinfo(local_addr);
+
             if (call_peer.ss_family == AF_INET) {
-                (_RCAST(struct sockaddr_in *,&call_peer))->sin_port = htons(port);
+                (_RCAST(struct sockaddr_in*, &call_peer))->sin_port = htons(port);
             } else {
-                (_RCAST(struct sockaddr_in6 *,&call_peer))->sin6_port = htons(port);
+                (_RCAST(struct sockaddr_in6*, &call_peer))->sin6_port = htons(port);
             }
-            memcpy(&call_socket->ss_dest, &call_peer, SOCK_ADDR_SIZE(_RCAST(struct sockaddr_storage *,&call_peer)));
+            memcpy(&call_socket->ss_dest, &call_peer,
+                   SOCK_ADDR_SIZE(_RCAST(struct sockaddr_storage*, &call_peer)));
 
             free(str_host);
             free(str_port);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -35,7 +35,7 @@
 #include <sys/resource.h>
 
 #ifdef __SUNOS
-#include<stdarg.h>
+#include <stdarg.h>
 #endif
 
 #include <unistd.h>
@@ -67,8 +67,11 @@ int screen_readkey()
 
 void screen_exit()
 {
-    if( backgroundMode == false )
-        endwin();
+    if (!screen_inited) {
+        return;
+    }
+
+    endwin();
 }
 
 void screen_show_errors() {
@@ -96,7 +99,7 @@ void screen_clear()
     printf("\033[2J");
 }
 
-void screen_set_exename(char * exe_name)
+void screen_set_exename(const char* exe_name)
 {
     strcpy(screen_exename, exe_name);
 }


### PR DESCRIPTION
To run valgrind:

    # make sipp without optimization
    make CFLAGS="-g -O0" CXXFLAGS="-g -O0"

    # run sipp with valgrind
    valgrind --partial-loads-ok=yes --show-leak-kinds=all \
      --leak-check=full \
      sipp SIPP_ARGUMENTS | cat

    # (the extra cat disables curses, which can show distracting leaks)