### PR TITLE
Explicitly bind tcp sockets to source port

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2722,6 +2722,25 @@ int open_connections()
         }
         sipp_customize_socket(tcp_multiplex);
 
+        if (user_port) {
+            int sock_opt = 1;
+
+            if (setsockopt(tcp_multiplex->ss_fd, SOL_SOCKET, SO_REUSEADDR, (void *)&sock_opt,
+                           sizeof (sock_opt)) == -1) {
+                ERROR_NO("setsockopt(SO_REUSEADDR) failed");
+            }
+
+            if (tcp_multiplex->ss_ipv6) {
+                struct sockaddr_in6 sa_loc = {AF_INET6};
+                sa_loc.sin6_port = htons(local_port);
+                sipp_bind_socket(tcp_multiplex, (struct sockaddr_storage*)&sa_loc, NULL);
+            } else {
+                struct sockaddr_in sa_loc = {AF_INET};
+                sa_loc.sin_port = htons(local_port);
+                sipp_bind_socket(tcp_multiplex, (struct sockaddr_storage*)&sa_loc, NULL);
+            }
+        }
+
         if (sipp_connect_socket(tcp_multiplex, &remote_sockaddr)) {
             if (reset_number > 0) {
                 WARNING("Failed to reconnect\n");


### PR DESCRIPTION
Quick workaround to get binding working. Also set `SO_REUSEADDR` for good measure.

Not the prettiest code but I want to get this in with minimal rework. I already want to try and change as much as I can to be AF_ independent and this will get cleaned up with that work.