### PR TITLE
Do not use std::bind

### DIFF
--- a/src/rtpstream.cpp
+++ b/src/rtpstream.cpp
@@ -766,7 +766,7 @@ static int rtpstream_get_localport (int *rtpsocket, int *rtcpsocket)
       (_RCAST(struct sockaddr_in *,&address))->sin_port=
         htons((short)port_number);
     }
-    if (bind(*rtpsocket,(sockaddr *)(void *)&address,
+    if (::bind(*rtpsocket,(sockaddr *)(void *)&address,
          SOCK_ADDR_SIZE(&address)) == 0) {
       break;
     }
@@ -797,7 +797,7 @@ static int rtpstream_get_localport (int *rtpsocket, int *rtcpsocket)
       (_RCAST(struct sockaddr_in *,&address))->sin_port=
         htons((short)port_number+1);
     }
-    if (bind(*rtcpsocket,(sockaddr *)(void *)&address,
+    if (::bind(*rtcpsocket,(sockaddr *)(void *)&address,
          SOCK_ADDR_SIZE(&address))) {
       /* could not bind the rtcp socket to required port. so we delete it */
       close (*rtcpsocket);

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -2193,7 +2193,7 @@ int main(int argc, char *argv[])
             // IPv6 address
             get_host_and_port(media_ip, media_ip_escaped, NULL);
 
-            if (bind(media_socket, (sockaddr*)&media_sockaddr,
+            if (::bind(media_socket, (sockaddr*)&media_sockaddr,
                      SOCK_ADDR_SIZE(&media_sockaddr)) == 0) {
                 break;
             }
@@ -2223,7 +2223,7 @@ int main(int argc, char *argv[])
             get_host_and_port(media_ip, media_ip_escaped, NULL);
         }
 
-        if (bind(media_socket_video, (sockaddr*)&media_sockaddr,
+        if (::bind(media_socket_video, (sockaddr*)&media_sockaddr,
                  SOCK_ADDR_SIZE(&media_sockaddr))) {
             ERROR_NO("Unable to bind video RTP socket (IP=%s, port=%d)",
                      media_ip, media_port + 2);

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -520,7 +520,7 @@ void setup_ctrl_socket()
 
     while (try_counter) {
         ((struct sockaddr_in *)&ctl_sa)->sin_port = htons(port);
-        if (!bind(sock, (struct sockaddr *)&ctl_sa, sizeof(struct sockaddr_in))) {
+        if (!::bind(sock, (struct sockaddr *)&ctl_sa, sizeof(struct sockaddr_in))) {
             /* Bind successful */
             break;
         }
@@ -1488,7 +1488,7 @@ int sipp_bind_socket(struct sipp_socket *socket, struct sockaddr_storage *saddr,
         len = sizeof(struct sockaddr_in);
     }
 
-    if ((ret = bind(socket->ss_fd, (sockaddr *)saddr, len))) {
+    if ((ret = ::bind(socket->ss_fd, (sockaddr *)saddr, len))) {
         return ret;
     }
 


### PR DESCRIPTION
Since include/stat.hpp contains "using namespace std;" calling bind calls std::bind of C++11. That will give errors (on OS X El Capitan) like
```
src/socket.cpp:523:13: error: invalid argument type '__bind<int &, sockaddr *, unsigned long>' to unary expression
        if (!bind(sock, (struct sockaddr *)&ctl_sa, sizeof(struct sockaddr_in))) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/socket.cpp:1491:14: error: assigning to 'int' from incompatible type '__bind<int &, sockaddr *, int &>'
    if ((ret = bind(socket->ss_fd, (sockaddr *)saddr, len))) {
             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This patch fixes those.
