### PR TITLE
Refactor sockaddr code for clarity

### DIFF
--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -32,6 +32,9 @@ enum ssl_init_status {
 extern  SSL_CTX  *sip_trp_ssl_ctx;
 extern  SSL_CTX  *sip_trp_ssl_ctx_client;
 
+int gai_getsockaddr(struct sockaddr_storage *ss, const char *host,
+                    short port, int flags, int family);
+
 const char *sip_tls_error_string(SSL *ssl, int size);
 ssl_init_status FI_init_ssl_context (void);
 #endif

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -32,9 +32,9 @@ enum ssl_init_status {
 extern  SSL_CTX  *sip_trp_ssl_ctx;
 extern  SSL_CTX  *sip_trp_ssl_ctx_client;
 
-int gai_getsockaddr(struct sockaddr_storage *ss, const char *host,
+int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,
                     short port, int flags, int family);
-void sockaddr_update_port(struct sockaddr_storage *ss, short port);
+void sockaddr_update_port(struct sockaddr_storage* ss, short port);
 
 const char *sip_tls_error_string(SSL *ssl, int size);
 ssl_init_status FI_init_ssl_context (void);

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -34,6 +34,7 @@ extern  SSL_CTX  *sip_trp_ssl_ctx_client;
 
 int gai_getsockaddr(struct sockaddr_storage *ss, const char *host,
                     short port, int flags, int family);
+void sockaddr_update_port(struct sockaddr_storage *ss, short port);
 
 const char *sip_tls_error_string(SSL *ssl, int size);
 ssl_init_status FI_init_ssl_context (void);

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -904,23 +904,7 @@ bool call::connect_socket_if_needed()
         }
 
         if (peripsocket) {
-            struct addrinfo * h ;
-            struct addrinfo   hints;
-            memset((char*)&hints, 0, sizeof(hints));
-            hints.ai_flags  = AI_PASSIVE;
-            hints.ai_family = PF_UNSPEC;
-            getaddrinfo(peripaddr,
-                        NULL,
-                        &hints,
-                        &h);
-            memcpy(&saddr, h->ai_addr, h->ai_addrlen);
-
-            if (use_ipv6) {
-                (_RCAST(struct sockaddr_in6*, &saddr))->sin6_port = htons(local_port);
-            } else {
-                (_RCAST(struct sockaddr_in*, &saddr))->sin_port = htons(local_port);
-            }
-            freeaddrinfo(h);
+            gai_getsockaddr(&saddr, peripaddr, local_port, AI_PASSIVE, AF_UNSPEC);
         }
 
         if (sipp_bind_socket(call_socket, &saddr, &call_port)) {
@@ -3644,27 +3628,14 @@ call::T_ActionResult call::executeAction(char * msg, message *curmsg)
                 }
             }
 
-            struct addrinfo   hints;
-            struct addrinfo * local_addr;
-            memset((char*)&hints, 0, sizeof(hints));
-            hints.ai_flags  = AI_PASSIVE;
-            hints.ai_family = PF_UNSPEC;
             is_ipv6 = false;
 
-            if (getaddrinfo(str_host, NULL, &hints, &local_addr) != 0) {
+            if (gai_getsockaddr(&call_peer, str_host, port,
+                                AI_PASSIVE, AF_UNSPEC) != 0) {
                 ERROR("Unknown host '%s' for setdest", str_host);
             }
-            if (_RCAST(struct sockaddr_storage *, local_addr->ai_addr)->ss_family != call_peer.ss_family) {
+            if (call_peer.ss_family != call_peer.ss_family) {
                 ERROR("Can not switch between IPv4 and IPV6 using setdest!");
-            }
-
-            memcpy(&call_peer, local_addr->ai_addr, local_addr->ai_addrlen);
-            freeaddrinfo(local_addr);
-
-            if (call_peer.ss_family == AF_INET) {
-                (_RCAST(struct sockaddr_in*, &call_peer))->sin_port = htons(port);
-            } else {
-                (_RCAST(struct sockaddr_in6*, &call_peer))->sin6_port = htons(port);
             }
 
             memcpy(&call_socket->ss_dest, &call_peer, sizeof(call_peer));

--- a/src/rtpstream.cpp
+++ b/src/rtpstream.cpp
@@ -759,13 +759,7 @@ static int rtpstream_get_localport (int *rtpsocket, int *rtcpsocket)
       next_rtp_port= min_rtp_port;
     }
 
-    if (media_ip_is_ipv6) {
-      (_RCAST(struct sockaddr_in6 *,&address))->sin6_port =
-        htons((short)port_number);
-    } else {
-      (_RCAST(struct sockaddr_in *,&address))->sin_port=
-        htons((short)port_number);
-    }
+    sockaddr_update_port(&address, port_number);
     if (::bind(*rtpsocket,(sockaddr *)(void *)&address,
                sizeof(address)) == 0) {
       break;
@@ -790,13 +784,7 @@ static int rtpstream_get_localport (int *rtpsocket, int *rtcpsocket)
   *rtcpsocket= socket(media_ip_is_ipv6?PF_INET6:PF_INET,SOCK_DGRAM,0);
   if (*rtcpsocket!=-1) {
     /* try to bind it to our preferred address */
-    if (media_ip_is_ipv6) {
-      (_RCAST(struct sockaddr_in6 *,&address))->sin6_port =
-        htons((short)port_number+1);
-    } else {
-      (_RCAST(struct sockaddr_in *,&address))->sin_port=
-        htons((short)port_number+1);
-    }
+    sockaddr_update_port(&address, port_number + 1);
     if (::bind(*rtcpsocket,(sockaddr *)(void *)&address,
                sizeof(address)) == 0) {
       /* could not bind the rtcp socket to required port. so we delete it */
@@ -959,18 +947,10 @@ void rtpstream_set_remote (rtpstream_callinfo_t *callinfo, int ip_ver, char *ip_
 
   /* Audio */
   if (audio_port) {
-    if (media_ip_is_ipv6) {
-      (_RCAST(struct sockaddr_in6 *,&address))->sin6_port= htons((short)audio_port);
-    } else {
-      (_RCAST(struct sockaddr_in *,&address))->sin_port= htons((short)audio_port);
-    }
+    sockaddr_update_port(&address, audio_port);
     memcpy (&(taskinfo->remote_audio_rtp_addr),&address,sizeof(address));
 
-    if (media_ip_is_ipv6) {
-      (_RCAST(struct sockaddr_in6 *,&address))->sin6_port= htons((short)audio_port+1);
-    } else {
-      (_RCAST(struct sockaddr_in *,&address))->sin_port= htons((short)audio_port+1);
-    }
+    sockaddr_update_port(&address, audio_port + 1);
     memcpy (&(taskinfo->remote_audio_rtcp_addr),&address,sizeof(address));
 
     taskinfo->flags&= ~TI_NULL_AUDIOIP;
@@ -978,18 +958,10 @@ void rtpstream_set_remote (rtpstream_callinfo_t *callinfo, int ip_ver, char *ip_
 
   /* Video */
   if (video_port) {
-    if (media_ip_is_ipv6) {
-      (_RCAST(struct sockaddr_in6 *,&address))->sin6_port= htons((short)video_port);
-    } else {
-      (_RCAST(struct sockaddr_in *,&address))->sin_port= htons((short)video_port);
-    }
+    sockaddr_update_port(&address, video_port);
     memcpy (&(taskinfo->remote_video_rtp_addr),&address,sizeof(address));
 
-    if (media_ip_is_ipv6) {
-      (_RCAST(struct sockaddr_in6 *,&address))->sin6_port= htons((short)video_port+1);
-    } else {
-      (_RCAST(struct sockaddr_in *,&address))->sin_port= htons((short)video_port+1);
-    }
+    sockaddr_update_port(&address, video_port + 1);
     memcpy (&(taskinfo->remote_video_rtcp_addr),&address,sizeof(address));
 
     taskinfo->flags&= ~TI_NULL_VIDEOIP;

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -2161,9 +2161,8 @@ int main(int argc, char *argv[])
         int max_tries = user_media_port ? 1 : 100;
         media_port = user_media_port ? user_media_port : DEFAULT_MEDIA_PORT;
         for (try_counter = 0; try_counter < max_tries; try_counter++) {
+            sockaddr_update_port(&media_sockaddr, media_port);
 
-	    sockaddr_update_port(&media_sockaddr, media_port);
-	    media_ip_is_ipv6 = media_sockaddr.ss_family == AF_INET6;
             // Use get_host_and_port to remove square brackets from an
             // IPv6 address
             get_host_and_port(media_ip, media_ip_escaped, NULL);
@@ -2185,12 +2184,11 @@ int main(int argc, char *argv[])
            (+1 is reserved for RTCP)
         ----------------------------------------------------------*/
 
-	sockaddr_update_port(&media_sockaddr, media_port + 2);
-	media_ip_is_ipv6 = media_sockaddr.ss_family == AF_INET6;
+        sockaddr_update_port(&media_sockaddr, media_port + 2);
 
-	// Use get_host_and_port to remove square brackets from an
-	// IPv6 address
-	get_host_and_port(media_ip, media_ip_escaped, NULL);
+        // Use get_host_and_port to remove square brackets from an
+        // IPv6 address
+        get_host_and_port(media_ip, media_ip_escaped, NULL);
 
         if (::bind(media_socket_video, (sockaddr*)&media_sockaddr,
                    sizeof(media_sockaddr))) {

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -2162,12 +2162,8 @@ int main(int argc, char *argv[])
         media_port = user_media_port ? user_media_port : DEFAULT_MEDIA_PORT;
         for (try_counter = 0; try_counter < max_tries; try_counter++) {
 
-            if (media_sockaddr.ss_family == AF_INET) {
-                (_RCAST(struct sockaddr_in*, &media_sockaddr))->sin_port = htons(media_port);
-            } else {
-                (_RCAST(struct sockaddr_in6*, &media_sockaddr))->sin6_port = htons(media_port);
-                media_ip_is_ipv6 = true;
-            }
+	    sockaddr_update_port(&media_sockaddr, media_port);
+	    media_ip_is_ipv6 = media_sockaddr.ss_family == AF_INET6;
             // Use get_host_and_port to remove square brackets from an
             // IPv6 address
             get_host_and_port(media_ip, media_ip_escaped, NULL);
@@ -2189,18 +2185,12 @@ int main(int argc, char *argv[])
            (+1 is reserved for RTCP)
         ----------------------------------------------------------*/
 
-        if (media_sockaddr.ss_family == AF_INET) {
-            (_RCAST(struct sockaddr_in*, &media_sockaddr))->sin_port = htons(media_port + 2);
-            // Use get_host_and_port to remove square brackets from an
-            // IPv6 address
-            get_host_and_port(media_ip, media_ip_escaped, NULL);
-        } else {
-            (_RCAST(struct sockaddr_in6*, &media_sockaddr))->sin6_port = htons(media_port + 2);
-            media_ip_is_ipv6 = true;
-            // Use get_host_and_port to remove square brackets from an
-            // IPv6 address
-            get_host_and_port(media_ip, media_ip_escaped, NULL);
-        }
+	sockaddr_update_port(&media_sockaddr, media_port + 2);
+	media_ip_is_ipv6 = media_sockaddr.ss_family == AF_INET6;
+
+	// Use get_host_and_port to remove square brackets from an
+	// IPv6 address
+	get_host_and_port(media_ip, media_ip_escaped, NULL);
 
         if (::bind(media_socket_video, (sockaddr*)&media_sockaddr,
                    sizeof(media_sockaddr))) {

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -1732,36 +1732,17 @@ int main(int argc, char *argv[])
                 if (temp_remote_s_p != 0) {
                     remote_s_p = temp_remote_s_p;
                 }
-                struct addrinfo   hints;
-                struct addrinfo * local_addr;
 
                 printf("Resolving remote sending address %s...\n", remote_s_address);
 
-                memset((char*)&hints, 0, sizeof(hints));
-                hints.ai_flags  = AI_PASSIVE;
-                hints.ai_family = PF_UNSPEC;
-
                 /* FIXME: add DNS SRV support using liburli? */
-                if (getaddrinfo(remote_s_address,
-                                NULL,
-                                &hints,
-                                &local_addr) != 0) {
+                if (gai_getsockaddr(&remote_sending_sockaddr, remote_s_address, remote_s_p,
+                                    AI_PASSIVE, AF_UNSPEC) != 0) {
                     ERROR("Unknown remote host '%s'.\n"
                           "Use 'sipp -h' for details", remote_s_address);
                 }
 
-                memcpy(&remote_sending_sockaddr,
-                       local_addr->ai_addr,
-                       local_addr->ai_addrlen);
-
-                if (remote_sending_sockaddr.ss_family == AF_INET) {
-                    (_RCAST(struct sockaddr_in*, &remote_sending_sockaddr))->sin_port = htons(remote_s_p);
-                } else {
-                    (_RCAST(struct sockaddr_in6*, &remote_sending_sockaddr))->sin6_port = htons(remote_s_p);
-                }
                 use_remote_sending_addr = 1;
-
-                freeaddrinfo(local_addr);
                 break;
             }
             case SIPP_OPTION_RTCHECK:

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -67,12 +67,12 @@ int pending_messages = 0;
 
 map<string, struct sipp_socket *>     map_perip_fd;
 
-int gai_getsockaddr(struct sockaddr_storage *ss, const char *host,
+int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,
                     short port, int flags, int family)
 {
     int error = 0;
     const struct addrinfo hints = {flags, family,};
-    struct addrinfo *res;
+    struct addrinfo* res;
 
     if (port) {
         char service[std::numeric_limits<short>::digits10 + 1];
@@ -90,17 +90,17 @@ int gai_getsockaddr(struct sockaddr_storage *ss, const char *host,
     return error;
 }
 
-void sockaddr_update_port(struct sockaddr_storage *ss, short port)
+void sockaddr_update_port(struct sockaddr_storage* ss, short port)
 {
     switch (ss->ss_family) {
     case AF_INET:
-	_RCAST(struct sockaddr_in *, ss)->sin_port = htons(port);
-	break;
+        _RCAST(struct sockaddr_in*, ss)->sin_port = htons(port);
+        break;
     case AF_INET6:
-	_RCAST(struct sockaddr_in6 *, ss)->sin6_port = htons(port);
-	break;
+        _RCAST(struct sockaddr_in6*, ss)->sin6_port = htons(port);
+        break;
     default:
-	ERROR("Unsupported family type");
+        ERROR("Unsupported family type");
     }
 }
 
@@ -2566,7 +2566,7 @@ int open_connections()
                     }
                 }
             }
-	    sockaddr_update_port(&local_sockaddr, l_port);
+            sockaddr_update_port(&local_sockaddr, l_port);
             if (sipp_bind_socket(main_socket, &local_sockaddr, &local_port) == 0) {
                 break;
             }
@@ -2598,7 +2598,7 @@ int open_connections()
             }
         }
 
-	sockaddr_update_port(&local_sockaddr, user_port);
+        sockaddr_update_port(&local_sockaddr, user_port);
         if (sipp_bind_socket(main_socket, &local_sockaddr, &local_port)) {
             ERROR_NO("Unable to bind main socket");
         }


### PR DESCRIPTION
Add two helpers, one wrapping the copypasta `getaddrinfo` logic, and one for wrapping the sockaddr port changing logic.

Seems to work under testing, makes the sockaddr code a lot easier to understand. Hopefully more refactoring will fall out as a result.