### PR TITLE
Move new sockaddr helpers out of the USE_OPENSSL section

### DIFF
--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -31,14 +31,15 @@ enum ssl_init_status {
 
 extern  SSL_CTX  *sip_trp_ssl_ctx;
 extern  SSL_CTX  *sip_trp_ssl_ctx_client;
+const char *sip_tls_error_string(SSL *ssl, int size);
+ssl_init_status FI_init_ssl_context (void);
+
+#endif // USE_OPENSSL
+
 
 int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,
                     unsigned short port, int flags, int family);
 void sockaddr_update_port(struct sockaddr_storage* ss, short port);
-
-const char *sip_tls_error_string(SSL *ssl, int size);
-ssl_init_status FI_init_ssl_context (void);
-#endif
 int flush_socket(struct sipp_socket *socket);
 int write_socket(struct sipp_socket *socket, const char *buffer, ssize_t len, int flags, struct sockaddr_storage *dest);
 void sipp_sctp_peer_params(struct sipp_socket *socket);


### PR DESCRIPTION
I noticed that master didn't compile - this was because I didn't have OpenSSL and a couple of the functions added recently were in an `#ifdef USE_OPENSSL` block.

This moves them out of that block and makes that block more obvious (removing some newlines in it and commenting the end).