### PR TITLE
Refactor SDP parsing (with more unit testing!)

### DIFF
--- a/include/call.hpp
+++ b/include/call.hpp
@@ -122,7 +122,7 @@ public:
     static   int   startDynamicId;  // offset for first dynamicId  FIXME:in CmdLine
     static   int   stepDynamicId;   // step of increment for dynamicId
     static   int   dynamicId;       // a counter for general use, incrementing  by  stepDynamicId starting at startDynamicId  wrapping at maxDynamicId  GLOBALY
-private:
+protected:
 
 
     unsigned int   tdm_map_number;
@@ -300,7 +300,7 @@ private:
 
     bool   use_ipv6;
 
-    void   get_remote_media_addr(char * message);
+    void get_remote_media_addr(std::string const &msg);
 
 #ifdef RTP_STREAM
     void extract_rtp_remote_addr(char* message);

--- a/include/rtpstream.hpp
+++ b/include/rtpstream.hpp
@@ -47,7 +47,7 @@ void rtpstream_shutdown(void);
 
 int rtpstream_get_audioport(rtpstream_callinfo_t *callinfo);
 int rtpstream_get_videoport(rtpstream_callinfo_t *callinfo);
-void rtpstream_set_remote(rtpstream_callinfo_t *callinfo, int ip_ver, char *ip_addr,
+void rtpstream_set_remote(rtpstream_callinfo_t* callinfo, int ip_ver, const char* ip_addr,
                           int audio_port, int video_port);
 
 int rtpstream_cache_file(char *filename);

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -39,6 +39,8 @@ ssl_init_status FI_init_ssl_context (void);
 
 int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,
                     unsigned short port, int flags, int family);
+int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,
+                    const char *service, int flags, int family);
 void sockaddr_update_port(struct sockaddr_storage* ss, short port);
 int flush_socket(struct sipp_socket *socket);
 int write_socket(struct sipp_socket *socket, const char *buffer, ssize_t len, int flags, struct sockaddr_storage *dest);

--- a/src/rtpstream.cpp
+++ b/src/rtpstream.cpp
@@ -584,7 +584,7 @@ int rtpstream_cache_file(char* filename)
 }
 
 /* code checked */
-void rtpstream_set_remote(rtpstream_callinfo_t* callinfo, int ip_ver, char* ip_addr,
+void rtpstream_set_remote(rtpstream_callinfo_t* callinfo, int ip_ver, const char* ip_addr,
                           int audio_port, int video_port)
 {
     struct sockaddr_storage   address;


### PR DESCRIPTION
Refactor the bizarrely over complicated sockaddr poking magic of the SDP
parser into two functions that reuse the new gai_getsockaddr helpers.

Bonus mockcall object and unit tests for the new parsing logic. Very
rudimentary, but should do the trick and lay some groundwork.