### PR TITLE
Fix use-after-free bug

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1046,9 +1046,14 @@ void SIPpSocket::abort() {
     int flags = fcntl(ss_fd, F_GETFL, 0);
     fcntl(ss_fd, F_SETFL, flags | O_NONBLOCK);
 
-    /* Actually close the socket. */
-    close();
-    ss_fd = -1;
+    int count = --ss_count;
+    if (count == 0) {
+        invalidate();
+        sockets_pending_reset.erase(this);
+        delete this;
+    } else {
+        ss_fd = -1;
+    }
 }
 
 void SIPpSocket::close()


### PR DESCRIPTION
This might need a revisit, probably shouldn't be doing `delete this`.

`close`, is successful, it does delete itself, making this a use after free bug. However, since its reference counted, its also possible it may not delete itself, making this legitimate statement.

Don't merge this blindly, not exactly sure what the intention is here or what the correct fix will be. Is it necessary? Should `close` do the `ss_fd = -1`? Should `close` return?