### PR TITLE
Fix incorrect packet length

### DIFF
--- a/include/prepare_pcap.h
+++ b/include/prepare_pcap.h
@@ -45,7 +45,7 @@ struct iphdr {
     u_int32_t saddr;
     u_int32_t daddr;
     /*The options start here. */
-};
+} __attribute__((packed));
 
 #endif
 


### PR DESCRIPTION
My bad, this looks like something caused by 4ae32a09c8fcd5e0b88b727e53cf96bd5e94433a (*why* is there a +4 hidden in there? that's not correct... unless its to compensate for structure padding).

Which leads to some questions:

- Why do we use the system's network structures for everything else but ip4?
- Did this code work on BSD/Cygwin (maybe we should add an OSX travis build)?

Now while I'm putting this up for review, I don't know if its ready to be merged. Its started causing some of our internal SIPp based tests to start to fail, claiming that DTMF packets are getting detected where we previous weren't. But now, and especially after looking at this code in depth, I wouldn't be surprised if it never worked. The packet payload offset calculation on ipv4 looks suspiciously broken.

---

Looks like the ipv4 packet length code is completely wrong.

The original code seems to be doing special logic on OSX, Cygwin and
FreeBSD, then again on HP UX and then again on Linux (and everything
else) because of, what I can only guess, must be differences in
structure padding. Mark the iphdr struct as packed for good measure.

There is no reason for the + 4, it shouldn't have slipped in.

Probably should use the system provided structures, like we're already
doing for ipv6. But one thing at a time.

Fixes #223.