### PR TITLE
Compile with _DEFAULT_SOURCE for newer Linux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ AM_CXXFLAGS=-I$(srcdir)/include -Wall -pedantic
 
 # For BSD-style elements in udphdr struct (uh_dport instead of dest)
 # among others.
-AM_CPPFLAGS=-D_BSD_SOURCE
+AM_CPPFLAGS=-D_BSD_SOURCE -D_DEFAULT_SOURCE
 
 CLEANFILES =
 EXTRA_DIST = \


### PR DESCRIPTION
Looks like the right way to deal with compatibility is to define both.