### PR TITLE
Improve Travis CI jobs and add OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,19 @@ matrix:
         - CC=gcc-4.6
         - CXX=g++-4.6
         - CONFOPTS="--with-gsl --with-openssl --with-pcap --with-rtpstream --with-sctp"
+    - os: osx
+      compiler: clang
+      env:
+        - CONFOPTS="--with-gsl --with-openssl --with-pcap --with-rtpstream"
 
 before_script:
   - autoreconf -vifs
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gsl; fi
   - ./configure $CONFOPTS
 
 script:
   - make -j2
   - make -j2 check
-  - ./regress/runtests
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then ./regress/runtests; fi
   - ./validate-src.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,63 @@
 # Config
 
 language: cpp
-
-notifications:
-    email: false
-
-# https://docs.travis-ci.com/user/ci-environment/
-# Use Trusty so we get a newer compiler which support c++11.
-sudo: required
+sudo: false
 dist: trusty
-
+cache: bundler
+notifications:
+  email: false
 
 # Build matrix (2x compiler, 1x confopts)
-
 compiler:
-    - gcc
-    - clang
+  - gcc
+  - clang
+
+addons:
+  apt:
+    packages:
+      - libpcap-dev
+      - libsctp-dev
+      - libncurses5-dev
+      - libssl-dev
+      - libgsl0-dev
 
 env:
-    - CONFOPTS="--with-gsl --with-openssl --with-pcap --with-rtpstream --with-sctp"
+  - CONFOPTS="--with-gsl --with-openssl --with-pcap --with-rtpstream --with-sctp"
 
 # Extend build matrix
-
 matrix:
-    include:
-        - compiler: gcc
-          env: CONFOPTS=""
-        - compiler: gcc
-          env: CONFOPTS="--with-openssl --without-pcap --without-rtpstream"
-        - compiler: gcc
-          env: CONFOPTS="--disable-epoll"
-        - compiler: gcc
-          addons:
-            apt:
-              packages:
-                - g++-4.6
-          env:
-            - COMPILER=gcc-4.6
-            - CONFOPTS="--with-gsl --with-openssl --with-pcap --with-rtpstream --with-sctp"
-
-
-# Build steps
-
-before_install:
-    - sudo apt-get -qq update
-    - sudo apt-get install -y libpcap-dev libsctp-dev libncurses5-dev libssl-dev libgsl0-dev
+  include:
+    - os: linux
+      compiler: gcc
+      env: CONFOPTS="--with-openssl --without-pcap --without-rtpstream"
+    - os: linux
+      compiler: gcc
+      env: CONFOPTS=""
+    - os: linux
+      compiler: gcc
+      env: CONFOPTS="--disable-epoll"
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - g++-4.6
+            - libpcap-dev
+            - libsctp-dev
+            - libncurses5-dev
+            - libssl-dev
+            - libgsl0-dev
+      env:
+        - CC=gcc-4.6
+        - CXX=g++-4.6
+        - CONFOPTS="--with-gsl --with-openssl --with-pcap --with-rtpstream --with-sctp"
 
 before_script:
-    - test "$COMPILER" = "gcc-4.6" && export CC=gcc-4.6 && export CXX=g++-4.6 || true
-    - git submodule update --init
-    - autoreconf -vifs
-    - ./configure $CONFOPTS
+  - autoreconf -vifs
+  - ./configure $CONFOPTS
 
 script:
-    - make -j2
-    - make -j2 check
-    - ./regress/runtests
-    - ./validate-src.sh
+  - make -j2
+  - make -j2 check
+  - ./regress/runtests
+  - ./validate-src.sh


### PR DESCRIPTION
I personally don't run anything other than Linux. Travis CI does offer doing OSX builds, so adding it to the continuous integration build should give us some more confidence changing on non-Linux platforms.

Also switched over to the new container style stuff (https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/), for much faster builds on Linux (4min instead of about 12). Took some time and try to clean things up a little bit too (for example, checking out submodules is redundant).

Only catch is the regress scripts don't run on OSX.