### PR TITLE
parsing: Improve Contact header parsing for next_url.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Bugs fixed in 3.5.x
 * Recompile entire source after a reconfigure.
 * Compile with -lncurses if -lcurses does not exist. (Issue #205, reported
   by Paul Malpass.)
+* Handle Contact header with extra angle brackets ('<...>') outside of the
+  uri-parameters (in the contact-params). The contact params should not be
+  used in the next_url. (Issue #234, reported by Justin Zimmer.)
 
 
 Bugs fixed in 3.5.1

--- a/include/call.hpp
+++ b/include/call.hpp
@@ -229,8 +229,8 @@ private:
     T_ActionResult last_action_result;
 
     /* rc == true means call not deleted by processing */
-    void formatNextReqUrl (char* next_req_url);
-    void computeRouteSetAndRemoteTargetUri (char* rrList, char* contact, bool bRequestIncoming);
+    void formatNextReqUrl(const char* contact);
+    void computeRouteSetAndRemoteTargetUri(const char* rrList, const char* contact, bool bRequestIncoming);
     bool matches_scenario(unsigned int index, int reply_code, char * request, char * responsecseqmethod, char *txn);
 
     bool executeMessage(message *curmsg);

--- a/regress/github-#0234/run
+++ b/regress/github-#0234/run
@@ -1,0 +1,17 @@
+#!/bin/sh
+# This regression test is a part of SIPp.
+# Author: Walter Doekes, OSSO B.V., 2016
+. "`dirname "$0"`/../functions"; init
+
+sippfg -m 1 -sf uas.xml -p 5070 >/dev/null 2>&1 &
+job=$!
+sippfg -m 1 -sf uac.xml 127.0.0.1:5070 \
+    -timeout 4 -timeout_error >/dev/null 2>&1
+status=$?
+wait $job || status=1
+
+if test $status -eq 0; then
+    ok
+else
+    fail "bad R-URI through [next_url]?"
+fi

--- a/regress/github-#0234/uac.xml
+++ b/regress/github-#0234/uac.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <send retrans="500" start_txn="invite">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv response="200" response_txn="invite" rrs="true"/>
+
+  <send retrans="500" ack_txn="invite">
+    <![CDATA[
+
+      ACK [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <timewait milliseconds="500"/>
+</scenario>

--- a/regress/github-#0234/uas.xml
+++ b/regress/github-#0234/uas.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <recv request="INVITE"/>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:user@1.2.3.4:58292;transport=tcp;alias=5.5.5.5~58292~2>;+sip.instance="<urn:uuid:0f35feab-c878-4622-a94e-b2e6e812b177>"
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv request="ACK">
+    <action>
+      <ereg regexp="ACK (sip:user@1\.2\.3\.4:58292;transport=tcp;alias=5\.5\.5\.5~58292~2) SIP/2\.0" search_in="msg" check_it="true" assign_to="all,ruri"/>
+    </action>
+  </recv>
+  <Reference variables="all,ruri"/>
+</scenario>


### PR DESCRIPTION
If there were additional ">" marks in the Contact header, after the
useraddr part, the Contact would come out wrong. For example:

     <sip:user@X.X.X.X:58292;transport=tcp;alias=Y.Y.Y.Y~58292~2>;
       +sip.instance="<urn:uuid:0f35feab-c878-4622-a94e-b2e6e812b177>"

That would not get stripped at "~2", but at the last ">".

Added regression test.

Reported by Justin Zimmer. Closes #234.