### PR TITLE
Fixes for TLS/OpenSSL calls

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1877,7 +1877,14 @@ int SIPpSocket::read_error(int ret)
     const char *errstring = strerror(errno);
 #ifdef USE_OPENSSL
     if (ss_transport == T_TLS) {
+        int err = SSL_get_error(ss_ssl, ret);
         errstring = sip_tls_error_string(ss_ssl, ret);
+        if (err == SSL_ERROR_WANT_READ) {
+            /* This is benign - we just need to wait for the socket to be
+             * readable again, which will happen naturally as part of the
+             * poll/epoll loop. */
+            return 1;
+        }
     }
 #endif
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1890,8 +1890,10 @@ int SIPpSocket::read_error(int ret)
     }
 #endif
 
-    /* We have only non-blocking reads, so this should not occur. */
-    if (ret < 0) {
+    /* We have only non-blocking reads, so this should not occur. The OpenSSL
+     * functions don't set errno, though, so this check doesn't make sense
+     * for TLS sockets. */
+    if ((ret < 0) && (ss_transport != T_TLS)) {
         assert(errno != EAGAIN);
     }
 


### PR DESCRIPTION
Fixes #241 and #243.

For #241, the issue was that the OpenSSL functions don't set errno - so checking errno after calling them didn't give valid results.

For #243, we now just return 1 from read_error when we hit SSL_ERROR_WANT_READ - this should avoid the code in read_error which closes the socket and the code at https://github.com/SIPp/sipp/blob/04c38740cbc6476050ca37754f7fdd272e5615bc/src/socket.cpp#L3022 which removes it from the list of file descriptors.