### PR TITLE
Fix bind/connect/sendto issue because of bad addrlen.

### DIFF
--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -35,6 +35,32 @@ ssl_init_status FI_init_ssl_context (void);
 
 #endif // USE_OPENSSL
 
+/**
+ * On some systems you must pass the exact sockaddr struct size to
+ * connect/bind/sendto calls. Passing a length that is too large
+ * causes EINVAL.
+ *
+ * For instance on OSX. If you don't, you'll get this:
+ * Unable to bind audio RTP socket (IP=X.X.X.X, port=6100), errno = 22
+ * (Invalid argument).
+ *
+ * Usage:
+ *
+ *   struct sockaddr_storage addr;
+ *   ...
+ *   bind(socket, (struct sockaddr*)&addr, socklen_from_addr(&addr));
+ */
+inline socklen_t socklen_from_addr(const struct sockaddr_storage* ss) {
+    if (ss->ss_family == AF_INET) {
+        return sizeof(struct sockaddr_in);
+    } else if (ss->ss_family == AF_INET6) {
+        return sizeof(struct sockaddr_in6);
+    } else {
+        assert(false);
+        return 0;
+    }
+}
+
 int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,
                     unsigned short port, int flags, int family);
 int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -178,7 +178,7 @@ int send_packets(play_args_t * play_args)
     struct sockaddr_in6 to6, from6;
     char buffer[PCAP_MAXPACKET];
     int temp_sum;
-    int len;
+    socklen_t len;
 
 #ifndef MSG_DONTWAIT
     int fd_flags;
@@ -189,22 +189,21 @@ int send_packets(play_args_t * play_args)
         if (sock < 0) {
             ERROR("Can't create raw IPv6 socket (need to run as root?): %s", strerror(errno));
         }
-        from_port = &(((struct sockaddr_in6 *)(void *) from )->sin6_port);
+        from_port = &(((struct sockaddr_in6 *)from)->sin6_port);
         len = sizeof(struct sockaddr_in6);
-        to_port = &(((struct sockaddr_in6 *)(void *) to )->sin6_port);
+        to_port = &(((struct sockaddr_in6 *)to)->sin6_port);
     } else {
         sock = socket(PF_INET, SOCK_RAW, IPPROTO_UDP);
-        from_port = &(((struct sockaddr_in *)(void *) from )->sin_port);
+        from_port = &(((struct sockaddr_in *)from)->sin_port);
         len = sizeof(struct sockaddr_in);
-        to_port = &(((struct sockaddr_in *)(void *) to )->sin_port);
+        to_port = &(((struct sockaddr_in *)to)->sin_port);
         if (sock < 0) {
             ERROR("Can't create raw IPv4 socket (need to run as root?): %s", strerror(errno));
             return ret;
         }
     }
 
-
-    if ((ret = bind(sock, (struct sockaddr *)(void *)from, len))) {
+    if ((ret = bind(sock, (struct sockaddr *)from, len))) {
         ERROR("Can't bind media raw socket");
         return ret;
     }
@@ -266,18 +265,18 @@ int send_packets(play_args_t * play_args)
 #ifdef MSG_DONTWAIT
         if (!media_ip_is_ipv6) {
             ret = sendto(sock, buffer, pkt_index->pktlen, MSG_DONTWAIT,
-                         (struct sockaddr *)(void *) to, sizeof(struct sockaddr_in));
+                         (struct sockaddr *)to, sizeof(struct sockaddr_in));
         } else {
             ret = sendto(sock, buffer, pkt_index->pktlen, MSG_DONTWAIT,
-                         (struct sockaddr *)(void *) &to6, sizeof(struct sockaddr_in6));
+                         (struct sockaddr *)&to6, sizeof(struct sockaddr_in6));
         }
 #else
         if (!media_ip_is_ipv6) {
             ret = sendto(sock, buffer, pkt_index->pktlen, 0,
-                         (struct sockaddr *)(void *) to, sizeof(struct sockaddr_in));
+                         (struct sockaddr *)to, sizeof(struct sockaddr_in));
         } else {
             ret = sendto(sock, buffer, pkt_index->pktlen, 0,
-                         (struct sockaddr *)(void *) &to6, sizeof(struct sockaddr_in6));
+                         (struct sockaddr *)&to6, sizeof(struct sockaddr_in6));
         }
 #endif
         if (ret < 0) {
@@ -288,7 +287,7 @@ int send_packets(play_args_t * play_args)
 
         rtp_pckts_pcap++;
         rtp_bytes_pcap += pkt_index->pktlen - sizeof(*udp);
-        memcpy (&last, &(pkt_index->ts), sizeof (struct timeval));
+        memcpy (&last, &(pkt_index->ts), sizeof(struct timeval));
         pkt_index++;
     }
 

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -1927,7 +1927,7 @@ int main(int argc, char *argv[])
             get_host_and_port(media_ip, media_ip_escaped, NULL);
 
             if (::bind(media_socket, (sockaddr*)&media_sockaddr,
-                       sizeof(media_sockaddr)) == 0) {
+                       socklen_from_addr(&media_sockaddr)) == 0) {
                 break;
             }
 
@@ -1950,7 +1950,7 @@ int main(int argc, char *argv[])
         get_host_and_port(media_ip, media_ip_escaped, NULL);
 
         if (::bind(media_socket_video, (sockaddr*)&media_sockaddr,
-                   sizeof(media_sockaddr))) {
+                   socklen_from_addr(&media_sockaddr))) {
             ERROR_NO("Unable to bind video RTP socket (IP=%s, port=%d)",
                      media_ip, media_port + 2);
         }

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -384,7 +384,7 @@ const char *sip_tls_error_string(SSL *ssl, int size)
 
 static char* get_inet_address(const struct sockaddr_storage* addr, char* dst, int len)
 {
-    if (getnameinfo(_RCAST(struct sockaddr*, addr), sizeof(*addr),
+    if (getnameinfo(_RCAST(struct sockaddr*, addr), socklen_from_addr(addr),
                     dst, len, NULL, 0, NI_NUMERICHOST) != 0) {
         snprintf(dst, len, "addr not supported");
     }
@@ -1550,7 +1550,7 @@ int SIPpSocket::connect(struct sockaddr_storage* dest)
     fcntl(ss_fd, F_SETFL, flags | O_NONBLOCK);
 
     errno = 0;
-    ret = ::connect(ss_fd, _RCAST(struct sockaddr *, &ss_dest), sizeof(ss_dest));
+    ret = ::connect(ss_fd, _RCAST(struct sockaddr *, &ss_dest), socklen_from_addr(&ss_dest));
     if (ret < 0) {
         if (errno == EINPROGRESS) {
             /* Block this socket until the connect completes - this is very similar to entering congestion, but we don't want to increment congestion statistics. */
@@ -2251,7 +2251,8 @@ ssize_t SIPpSocket::write_primitive(const char* buffer, size_t len,
             TRACE_MSG("---\nCompressed message len: %zu\n", len);
         }
 
-        rc = sendto(ss_fd, buffer, len, 0, _RCAST(struct sockaddr*, dest), sizeof(*dest));
+        rc = sendto(ss_fd, buffer, len, 0, _RCAST(struct sockaddr*, dest),
+                    socklen_from_addr(dest));
         break;
 
     default:


### PR DESCRIPTION
In 4aa361d, the SOCK_ADDR_SIZE macro was removed and in bind(),
connect() and sendto() calls, it was replaced with sizeof(struct
sockaddr_storage). Unfortunately some systems (OSX) refuse to work
with an inexact (too large) addrlen.

Thanks to @sjthomason for reporting and bisecting the cause.
Closes #246.