### PR TITLE
Snom patch: header value syntax

### DIFF
--- a/regress/github-header-values/run
+++ b/regress/github-header-values/run
@@ -1,0 +1,22 @@
+#!/bin/sh
+# This regression test is a part of SIPp.
+# Author: Walter Doekes, OSSO B.V., 2016
+. "`dirname "$0"`/../functions"; init
+
+sippfg -m 1 -sf uas.xml -p 5070 \
+    -trace_logs -log_file log.log >/dev/null 2>&1 &
+job=$!
+sippfg -m 1 -sf uac.xml 127.0.0.1:5070 \
+    -timeout 4 -timeout_error >/dev/null 2>&1
+status=$?
+wait $job || status=1
+
+if test $status -eq 0; then
+    if grep -e ^LAST\ From:\ \"Tom\ Jones\"\ \<sip:tom.jones@wales.uk\>\;tag=SIPpTag001$ log.log > /dev/null; then
+        ok
+    else
+        fail "From header not found"
+    fi
+else
+    fail "process failure"
+fi

--- a/regress/github-header-values/uac.xml
+++ b/regress/github-header-values/uac.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <send retrans="500" start_txn="invite">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=justafake
+      From: "Tom Jones" <sip:tom.jones@wales.uk>;tag=SIPpTag00[call_number]
+      To: "Fromage" <sip:cheese@paris.fr>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv response="200" response_txn="invite" rrs="true"/>
+
+  <send retrans="500" ack_txn="invite">
+    <![CDATA[
+
+      ACK [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=justafake
+      From: "Tom Jones" <sip:tom.jones@wales.uk>;tag=SIPpTag00[call_number]
+      To: "Fromage" <sip:cheese@paris.fr>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv request="BYE"/>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <timewait milliseconds="500"/>
+</scenario>

--- a/regress/github-header-values/uas.xml
+++ b/regress/github-header-values/uas.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <recv request="INVITE"/>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      Via: [last_Via!]
+      From: [last_From!]
+      To: [last_To!];tag=[pid]SIPpTag00[call_number]
+      Call-ID: [last_Call-ID!]
+      CSeq: [last_CSeq!]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!--
+
+    If you forget start_line="true" here, the headers will be found by value,
+    causing '''From: "Tom ...''' to match as the first "To"-header.
+
+  -->
+  <recv request="ACK" rrs="true">
+    <action>
+      <ereg regexp=": *(.*)" search_in="hdr" header="From" start_line="true" assign_to="_,them"/>
+      <ereg regexp=": *(.*)" search_in="hdr" header="To" start_line="true" assign_to="_,us"/>
+      <log message="LAST Via: [last_Via!]"/>
+      <log message="LAST From: [last_From!]"/>
+      <log message="LAST To: [last_To!]"/>
+    </action>
+  </recv>
+  <Reference variables="_"/>
+
+  <send retrans="500">
+    <![CDATA[
+
+      BYE [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: [$us]
+      To: [$them]
+      Call-ID: [call_id]
+      CSeq: 2 BYE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv response="200"/>
+
+  <timewait milliseconds="500"/>  
+</scenario>

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -923,9 +923,18 @@ char * call::get_last_header(const char * name)
     if (name[len - 1] == ':') {
         return get_header(last_recv_msg, name, false);
     } else {
+        bool content = false;
+        char no_colon[MAX_HEADER_LEN];
         char with_colon[MAX_HEADER_LEN];
-        sprintf(with_colon, "%s:", name);
-        return get_header(last_recv_msg, with_colon, false);
+        if (name[len-1] == '!') {
+            content = true;
+            snprintf(no_colon, len, "%s", name);
+            sprintf(with_colon, "%s:", no_colon);
+        }
+        else {
+            sprintf(with_colon, "%s", name);
+        }
+        return get_header(last_recv_msg, with_colon, content);
     }
 }
 


### PR DESCRIPTION
**Last header value:** you can extract the header value using the *!* suffix to the `[last_headerName]`

**Example:**
`To: [last_From!]`

will generates a *To:* header containing the last From header value, this is quite useful when you need to send a new request (Eg. re-INVITE into an inbound SIP dialog)

Of course you can do the same using a regexp, but this syntax simplifies a lot the scenario file.

*All the attribution for this patch should go to Snom Technology AG*