### PR TITLE
use remote host family as hint (if applicable) when opening connections

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2491,6 +2491,7 @@ void SIPpSocket::close_calls()
 int open_connections()
 {
     int status=0;
+    int family_hint = PF_UNSPEC;
     local_port = 0;
 
     if (!strlen(remote_host)) {
@@ -2516,6 +2517,7 @@ int open_connections()
             }
 
             get_inet_address(&remote_sockaddr, remote_ip, sizeof(remote_ip));
+            family_hint = remote_sockaddr.ss_family;
             if (remote_sockaddr.ss_family == AF_INET) {
                 strcpy(remote_ip_escaped, remote_ip);
             } else {
@@ -2542,7 +2544,7 @@ int open_connections()
 
         memset((char*)&hints, 0, sizeof(hints));
         hints.ai_flags  = AI_PASSIVE;
-        hints.ai_family = PF_UNSPEC;
+        hints.ai_family = family_hint;
 
         /* Resolving local IP */
         if (getaddrinfo(local_host, NULL, &hints, &local_addr) != 0) {


### PR DESCRIPTION
I recently had issues where open_connections would inconveniently retrieve an ipv6 address by default while we intend to communicate to a remote host via an ipv4 address. This fix intends to provide a better hint when creating the socket.

The error previously raised was: "Unable to send UDP message : Invalid argument".