### PR TITLE
Fix for Bug#237 to stop a crash when play_dtmf is used.

### DIFF
--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -1617,7 +1617,7 @@ void scenario::parseAction(CActions *actions)
                 hasMedia = 1;
                 free(ptr);
             } else if ((cptr = xp_get_value("play_dtmf"))) {
-                tmpAction->setMessage(ptr);
+                tmpAction->setMessage(cptr);
                 tmpAction->setActionType(CAction::E_AT_PLAY_DTMF);
                 hasMedia = 1;
 #else


### PR DESCRIPTION
Two changes:

1. Fix for [Bug#237](https://github.com/SIPp/sipp/issues/237).
2. Also modified gitignore to ignore core files as I ended up with a core file in my working directory.

Issue 237 was first replicated, causing sipp to crash and produce a core file. The core file was debugged to trace back to the root cause of the crash. The scenario was re-tested with the modified code and it now runs ok and RFC2833 DTMF events are being generated.
