### PR TITLE
couple of warnings

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -978,12 +978,10 @@ void SIPpSocket::invalidate()
             WARNING_NO("Failed to delete FD from epoll");
         }
 #endif
-        if (shutdown(ss_fd, SHUT_RDWR) < 0) {
-            WARNING_NO("Failed to shutdown socket %d", ss_fd);
-        }
-
-        if (::close(ss_fd) < 0) {
-            WARNING_NO("Failed to close socket %d", ss_fd);
+        if (ss_transport != T_UDP) {
+            if (shutdown(ss_fd, SHUT_RDWR) < 0) {
+                WARNING_NO("Failed to shutdown socket %d", ss_fd);
+            }
         }
 
 #ifdef USE_SCTP
@@ -994,6 +992,13 @@ void SIPpSocket::invalidate()
             }
         }
 #endif
+
+        if (::close(ss_fd) < 0) {
+            WARNING_NO("Failed to close socket %d", ss_fd);
+        }
+        else {
+            ss_fd = -1;
+        }
 
         abort();
     }


### PR DESCRIPTION
- shutdown(2) for UDP sockets returns ENOTCONN
- SO_LINGER should be set before close(2) while using SCTP
- it's better to set socket to -1 after close(2)