### PR TITLE
Ignore <?xml-model> element on XML

### DIFF
--- a/src/xp_parser.c
+++ b/src/xp_parser.c
@@ -299,6 +299,11 @@ char *xp_open_element(int index)
                 if (!doctype_end)
                     return NULL;
                 ptr = doctype_end;
+            } else if (strstartswith(ptr, "<?xml-model")) {
+                char *xmlmodel_end = strstr(ptr, ">");
+                if (!xmlmodel_end)
+                    return NULL;
+                ptr = xmlmodel_end;
             } else if (*(ptr+1) == '/') {
                 level--;
                 if (level < 0)


### PR DESCRIPTION
Ignore <?xml-model> element to accept others schema language for XML, like RELAX NG.

For link a XML file to a RELAX NG is necessary to include the element:

`<?xml-model href="file.rnc" type="application/relax-ng-compact-syntax"?>`

Today the sipp only accept the `<!DOCTYPE scenario SYSTEM "sipp.dtd">`