### PR TITLE
On error from pcap_open_offline use errbuf instead of errno

### DIFF
--- a/src/prepare_pcap.c
+++ b/src/prepare_pcap.c
@@ -202,7 +202,7 @@ int prepare_pkts(const char* file, pcap_pkts* pkts)
 
     pcap = pcap_open_offline(file, errbuf);
     if (!pcap)
-        ERROR_NO("Can't open PCAP file '%s'", file);
+        ERROR("Can't open PCAP file '%s': %s", file, errbuf);
 #ifdef HAVE_PCAP_NEXT_EX
     while (pcap_next_ex(pcap, &pkthdr, &pktdata) == 1) {
 #else


### PR DESCRIPTION
The function takes care of filling errbuf with the text for errno, and
in case of internal format errors or other non-system errors errno can
be 0, and we get an undetermined error message.