### PR TITLE
Support escaped brackets inside messages

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -154,6 +154,12 @@ SendingMessage::SendingMessage(scenario* msg_scenario, const char* const_src, bo
                 *dest++ = val & 0xff;
             }
             src++;
+        } else if ((*src == '\\') && (*(src+1) == '[')) {
+            src += 2;
+            *dest++ = '[';
+        } else if ((*src == '\\') && (*(src+1) == ']')) {
+            src += 2;
+            *dest++ = ']';
         } else if (*src == '\n') {
             *dest++ = '\r';
             *dest++ = *src++;


### PR DESCRIPTION
Sometimes it's necessary to add square brackets inside a message.
Anything inside brackets is normally treated as a keyword. With this
commit it's possible to escape brackets with a leading backslash.