### PR TITLE
SSL: separate CA file

### DIFF
--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -119,6 +119,7 @@
 #define DEFAULT_TLS_CERT           "cacert.pem"
 #define DEFAULT_TLS_KEY            "cakey.pem"
 #define DEFAULT_TLS_CRL            ""
+#define DEFAULT_TLS_CA             ""
 #endif
 
 #define TRANSPORT_TO_STRING(p)     ((p==T_TCP) ? "TCP" : ((p==T_TLS)? "TLS" : ((p==T_UDP)? "UDP" : "SCTP")))
@@ -322,6 +323,7 @@ extern SSL              * twinSipp_ssl;
 extern const char       * tls_cert_name           _DEFVAL(DEFAULT_TLS_CERT);
 extern const char       * tls_key_name            _DEFVAL(DEFAULT_TLS_KEY);
 extern const char       * tls_crl_name            _DEFVAL(DEFAULT_TLS_CRL);
+extern const char       * tls_ca_name             _DEFVAL(DEFAULT_TLS_CA);
 
 #endif
 

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -165,10 +165,12 @@ struct sipp_option options_table[] = {
     {"tls_cert", "Set the name for TLS Certificate file. Default is 'cacert.pem", SIPP_OPTION_STRING, &tls_cert_name, 1},
     {"tls_key", "Set the name for TLS Private Key file. Default is 'cakey.pem'", SIPP_OPTION_STRING, &tls_key_name, 1},
     {"tls_crl", "Set the name for Certificate Revocation List file. If not specified, X509 CRL is not activated.", SIPP_OPTION_STRING, &tls_crl_name, 1},
+    {"tls_ca", "Set the name for TLS CA file. If not specified, X509 verification is not activated.", SIPP_OPTION_STRING, &tls_ca_name, 1},
 #else
     {"tls_cert", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},
     {"tls_key", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},
     {"tls_crl", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},
+    {"tls_ca", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},
 #endif
 
 #ifdef USE_SCTP

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2111,8 +2111,10 @@ ssl_init_status FI_init_ssl_context (void)
     }
 
     /*  Load the trusted CA's */
-    SSL_CTX_load_verify_locations(sip_trp_ssl_ctx, tls_cert_name, NULL);
-    SSL_CTX_load_verify_locations(sip_trp_ssl_ctx_client, tls_cert_name, NULL);
+    if (strlen(tls_ca_name) != 0) {
+        SSL_CTX_load_verify_locations(sip_trp_ssl_ctx, tls_ca_name, NULL);
+        SSL_CTX_load_verify_locations(sip_trp_ssl_ctx_client, tls_ca_name, NULL);
+    }
 
     /*  CRL load from application specified only if specified on the command line */
     if (strlen(tls_crl_name) != 0) {
@@ -2125,6 +2127,13 @@ ssl_init_status FI_init_ssl_context (void)
             ERROR("FI_init_ssl_context: Unable to load CRL (client) file (%s)", tls_crl_name);
             return SSL_INIT_ERROR;
         }
+    }
+
+    /*
+     * TLS Verification only makes sense if an CA is specified or
+     * we require CRL validation.
+     */
+    if (strlen(tls_ca_name) != 0 || strlen(tls_crl_name) != 0) {
         /* The following call forces to process the certificates with the */
         /* initialised SSL_CTX                                            */
         SSL_CTX_set_verify(sip_trp_ssl_ctx,


### PR DESCRIPTION
This commit allows using a separate file to specify the CA to trust.
This way we have two files (cert, key) for our own certificate and
one file with the trusted CA.  Putting the own certificate and the CA
in the same file, as previously done with the tls_cert option, does
not seem to work.