### PR TITLE
bugfix: add extra \r\n\r\n only after all neccessary filtering

### DIFF
--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -613,10 +613,6 @@ static char* clean_cdata(char *ptr, int *removed_crlf = NULL)
         *ptr-- = 0;
     }
 
-    if(!strstr(msg, "\n\n")) {
-        strcat(msg, "\n\n");
-    }
-
     if(ptr == msg) {
         ERROR("Empty cdata in xml scenario file");
     }
@@ -631,6 +627,10 @@ static char* clean_cdata(char *ptr, int *removed_crlf = NULL)
     }
     while ((ptr = strstr(msg, "\t\n"))) {
         memmove(ptr, ptr + 1, strlen(ptr));
+    }
+
+    if(!strstr(msg, "\n\n")) {
+        strcat(msg, "\n\n");
     }
 
     return msg;


### PR DESCRIPTION
In some cases user may enter \r\n\t\r\n between message header and body. Then Content-Length: [len] is miscalculated. The problem is that \r\n\r\n is not found before filtering and thus extra \r\n\r\n is added at the end of the message as if there is no message body present at all.

[test.xml.zip](https://github.com/SIPp/sipp/files/1832751/test.xml.zip)

Content-Length must be 232 instead of 234 in such case.