### PR TITLE
Fix traffic thread crash

### DIFF
--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -1991,15 +1991,15 @@ int main(int argc, char *argv[])
         }
     }
 
-    traffic_thread();
-
-    /* Clean up */
-    if (!nostdin) {
-        stdin_socket->close();
-        stdin_socket = NULL; /* close "delete's this" */
+    if (traffic_thread()) {
+        /* Clean up */
+        if (!nostdin) {
+            stdin_socket->close();
+            stdin_socket = NULL; /* close "delete's this" */
+        }
+        ctrl_socket->close();
+        ctrl_socket = NULL;  /* close "delete's this" */
     }
-    ctrl_socket->close();
-    ctrl_socket = NULL;  /* close "delete's this" */
 
     /* Cancel and join other threads. */
     if (pthread2_id) {


### PR DESCRIPTION
Crash was introduced by commit f2cf583bd237467c33be7bb892d46c8c6c4adf79 when an if w/curly braces surrounding the call to traffic_thread() was forgotten.