### PR TITLE
Fix traffic thread crash upon shutdown

### DIFF
--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -1991,15 +1991,15 @@ int main(int argc, char *argv[])
         }
     }
 
-    traffic_thread();
-
-    /* Clean up */
-    if (!nostdin) {
-        stdin_socket->close();
-        stdin_socket = NULL; /* close "delete's this" */
+    if (traffic_thread()) {
+        /* Clean up */
+        if (!nostdin) {
+            stdin_socket->close();
+            stdin_socket = NULL; /* close "delete's this" */
+        }
+        ctrl_socket->close();
+        ctrl_socket = NULL;  /* close "delete's this" */
     }
-    ctrl_socket->close();
-    ctrl_socket = NULL;  /* close "delete's this" */
 
     /* Cancel and join other threads. */
     if (pthread2_id) {
@@ -2021,6 +2021,8 @@ int main(int argc, char *argv[])
 #endif
 
     free(scenario_file);
+    ctrl_socket->close();
+    ctrl_socket = NULL; /* close "delete's this" */
 
     sipp_exit(EXIT_TEST_RES_UNKNOWN);
 }


### PR DESCRIPTION
Commit f2cf583b intended to remove a double free upon shutdown but ended up causing a crash - this attempts to fix the problem.