### PR TITLE
Implement "-tls_version <x>" parameter to select which TLS protocol v…

### DIFF
--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -315,6 +315,7 @@ extern bool               tdm_map[1024];
 extern const char       * tls_cert_name           _DEFVAL(DEFAULT_TLS_CERT);
 extern const char       * tls_key_name            _DEFVAL(DEFAULT_TLS_KEY);
 extern const char       * tls_crl_name            _DEFVAL(DEFAULT_TLS_CRL);
+extern double             tls_version             _DEFVAL(1.2);
 #endif
 
 extern char*              scenario_file           _DEFVAL(NULL);

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -165,6 +165,7 @@ struct sipp_option options_table[] = {
     {"tls_cert", "Set the name for TLS Certificate file. Default is 'cacert.pem", SIPP_OPTION_STRING, &tls_cert_name, 1},
     {"tls_key", "Set the name for TLS Private Key file. Default is 'cakey.pem'", SIPP_OPTION_STRING, &tls_key_name, 1},
     {"tls_crl", "Set the name for Certificate Revocation List file. If not specified, X509 CRL is not activated.", SIPP_OPTION_STRING, &tls_crl_name, 1},
+    {"tls_version", "Set the TLS protocol version to use (1.0, 1.1, 1.2) -- default is 1.2", SIPP_OPTION_FLOAT, &tls_version, 1},
 #else
     {"tls_cert", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},
     {"tls_key", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -170,6 +170,7 @@ struct sipp_option options_table[] = {
     {"tls_cert", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},
     {"tls_key", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},
     {"tls_crl", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},
+    {"tls_version", NULL, SIPP_OPTION_NEED_SSL, NULL, 1},
 #endif
 
 #ifdef USE_SCTP

--- a/src/sslsocket.cpp
+++ b/src/sslsocket.cpp
@@ -22,10 +22,6 @@
 
 #ifdef USE_OPENSSL
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define TLS_method TLSv1_2_method
-#endif
-
 #define MUTEX_TYPE pthread_mutex_t
 #define MUTEX_SETUP(x) pthread_mutex_init(&(x), NULL)
 #define MUTEX_CLEANUP(x) pthread_mutex_destroy(&(x))
@@ -190,15 +186,35 @@ static int sip_tls_load_crls(SSL_CTX* ctx , const char* crlfile)
 /************* Prepare the SSL context ************************/
 enum tls_init_status TLS_init_context(void)
 {
-    sip_trp_ssl_ctx = SSL_CTX_new(TLS_method());
+    if (tls_version == 1.0) {
+        sip_trp_ssl_ctx = SSL_CTX_new(TLSv1_method());
+    } else if (tls_version == 1.1) {
+        sip_trp_ssl_ctx = SSL_CTX_new(TLSv1_1_method());
+    } else if (tls_version == 1.2) {
+        sip_trp_ssl_ctx = SSL_CTX_new(TLSv1_2_method());
+    } else {
+        ERROR("Unrecognized TLS version for generic context: %1.1f\n", tls_version);
+        sip_trp_ssl_ctx = NULL;
+    }
+
     if (sip_trp_ssl_ctx == NULL) {
-        ERROR("TLS_init_context: SSL_CTX_new with TLS_method failed");
+        ERROR("TLS_init_context: SSL_CTX_new with TLS_method failed for generic context");
         return TLS_INIT_ERROR;
     }
 
-    sip_trp_ssl_ctx_client = SSL_CTX_new(TLS_method());
+    if (tls_version == 1.0) {
+        sip_trp_ssl_ctx_client = SSL_CTX_new(TLSv1_method());
+    } else if (tls_version == 1.1) {
+        sip_trp_ssl_ctx_client = SSL_CTX_new(TLSv1_1_method());
+    } else if (tls_version == 1.2) {
+        sip_trp_ssl_ctx_client = SSL_CTX_new(TLSv1_2_method());
+    } else {
+        ERROR("Unrecognized TLS version for client context: %1.1f\n", tls_version);
+        sip_trp_ssl_ctx_client = NULL;
+    }
+
     if (sip_trp_ssl_ctx_client == NULL) {
-        ERROR("TLS_init_context: SSL_CTX_new with TLS_method failed");
+        ERROR("TLS_init_context: SSL_CTX_new with TLS_method failed for client context");
         return TLS_INIT_ERROR;
     }
 

--- a/src/sslsocket.cpp
+++ b/src/sslsocket.cpp
@@ -181,37 +181,37 @@ static int sip_tls_load_crls(SSL_CTX* ctx , const char* crlfile)
     return (1);
 }
 
+static SSL_CTX* instantiate_ssl_context(const char* context_name)
+{
+    SSL_CTX* ssl_ctx = NULL;
+
+    if (tls_version == 1.0) {
+        ssl_ctx = SSL_CTX_new(TLSv1_method());
+    } else if (tls_version == 1.1) {
+        ssl_ctx = SSL_CTX_new(TLSv1_1_method());
+    } else if (tls_version == 1.2) {
+        ssl_ctx = SSL_CTX_new(TLSv1_2_method());
+    } else {
+        ERROR("Unrecognized TLS version for [%s] context: %1.1f\n", context_name, tls_version);
+        ssl_ctx = NULL;
+    }
+
+    return ssl_ctx;
+}
+
 #endif //USE_OPENSSL
 
 /************* Prepare the SSL context ************************/
 enum tls_init_status TLS_init_context(void)
 {
-    if (tls_version == 1.0) {
-        sip_trp_ssl_ctx = SSL_CTX_new(TLSv1_method());
-    } else if (tls_version == 1.1) {
-        sip_trp_ssl_ctx = SSL_CTX_new(TLSv1_1_method());
-    } else if (tls_version == 1.2) {
-        sip_trp_ssl_ctx = SSL_CTX_new(TLSv1_2_method());
-    } else {
-        ERROR("Unrecognized TLS version for generic context: %1.1f\n", tls_version);
-        sip_trp_ssl_ctx = NULL;
-    }
+    sip_trp_ssl_ctx = instantiate_ssl_context("generic");
 
     if (sip_trp_ssl_ctx == NULL) {
         ERROR("TLS_init_context: SSL_CTX_new with TLS_method failed for generic context");
         return TLS_INIT_ERROR;
     }
 
-    if (tls_version == 1.0) {
-        sip_trp_ssl_ctx_client = SSL_CTX_new(TLSv1_method());
-    } else if (tls_version == 1.1) {
-        sip_trp_ssl_ctx_client = SSL_CTX_new(TLSv1_1_method());
-    } else if (tls_version == 1.2) {
-        sip_trp_ssl_ctx_client = SSL_CTX_new(TLSv1_2_method());
-    } else {
-        ERROR("Unrecognized TLS version for client context: %1.1f\n", tls_version);
-        sip_trp_ssl_ctx_client = NULL;
-    }
+    sip_trp_ssl_ctx_client = instantiate_ssl_context("client");
 
     if (sip_trp_ssl_ctx_client == NULL) {
         ERROR("TLS_init_context: SSL_CTX_new with TLS_method failed for client context");


### PR DESCRIPTION
…ersion to use (1.0, 1.1 or 1.2)

Commit "55329031" changed the behavior of TLS_init_context()
to always use TLS v1.2.  However when using TLS with non-SIPP
endpoints this can cause issues if they do not support v1.2.

This change allows explicitly specifying which TLS protocol
version to use on the commandline (default is 1.2).