### PR TITLE
Add playback file name option

### DIFF
--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -321,6 +321,8 @@ extern double             tls_version             _DEFVAL(1.2);
 extern char*              scenario_file           _DEFVAL(NULL);
 extern_c char*            scenario_path           _DEFVAL(NULL);
 
+extern char*              playback_file           _DEFVAL(NULL);
+
 // extern field file management
 typedef std::map<string, FileContents *> file_map;
 extern file_map inFiles;

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -480,6 +480,10 @@ void CAction::setPcapArgs(const char* P_value)
         M_pcapArgs = NULL;
     }
 
+    if (playback_file != NULL) {
+        P_value = playback_file;
+    }
+
     if(P_value != NULL) {
         M_pcapArgs = (pcap_pkts *) malloc(sizeof(*M_pcapArgs));
         if (parse_play_args(P_value, M_pcapArgs) == -1) {
@@ -497,6 +501,10 @@ void CAction::setRTPStreamActInfo(const char* P_value)
 {
     char* param_str;
     char* next_comma;
+
+    if (playback_file != NULL) {
+        P_value = playback_file;
+    }
 
     if (strlen(P_value) >= sizeof(M_rtpstream_actinfo.filename)) {
         ERROR("Filename %s is too long, maximum supported length %zu\n", P_value,

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -376,6 +376,8 @@ struct sipp_option options_table[] = {
     {"ringbuffer_size", "How large should error, message, shortmessage and calldebug files be before they get rotated?", SIPP_OPTION_LONG_LONG, &ringbuffer_size, 1},
     {"max_log_size", "What is the limit for error, message, shortmessage and calldebug file sizes.", SIPP_OPTION_LONG_LONG, &max_log_size, 1},
 
+    {"playback_file", "Name of the file to playback in exec play_pacp_audio or exec rtp_stream.", SIPP_OPTION_STRING, &playback_file, 1},
+
 };
 
 static struct sipp_option *find_option(const char* option) {


### PR DESCRIPTION
Can be used from the commandline to pass name of the file
to be used as a playback in scenario for "exec play_pcap_audio"
and "exec rtp_stream" actions:

    <exec play_pcap_audio="pcap/test1.pcap"/>
    <exec rtp_stream="pcap/test2.raw"/>

Usage:

    sipp -playback_file pcap/test3.pcap (will play test3.pcap instead of test1/2.pcap).

This way the same scenario file can be used for playing different playback files
without the need to change the scenario file.