### PR TITLE
DocUpdate01: External link - review and update

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -124,9 +124,9 @@ Installing SIPp
       it interfers with pthread.h from cygwin
     + Compile according to the instructions above.
 
-.. _GNU GPL license: http://www.gnu.org/copyleft/gpl.html
-.. _Gnu Scientific Libraries: http://www.gnu.org/software/gsl/
-.. _WinPcap developer package: http://www.winpcap.org/devel.htm
-.. _hewlett-packard: http://www.hp.com/
+.. _GNU GPL license: https://www.gnu.org/copyleft/gpl.html
+.. _Gnu Scientific Libraries: https://www.gnu.org/software/gsl/
+.. _WinPcap developer package: https://www.winpcap.org/devel.htm
+.. _hewlett-packard: https://www.hp.com/
 .. _SIPp's master tree: https://github.com/SIPp/sipp/tree/master
-.. _OpenSSL library: http://www.openssl.org/
+.. _OpenSSL library: https://www.openssl.org/

--- a/docs/media.rst
+++ b/docs/media.rst
@@ -50,13 +50,13 @@ SIPp comes with a G711 alaw pre-recorded pcap file and out of band
 (:rfc:`2833`) DTMFs in the pcap/ directory.
 
 .. warning::
-	The PCAP play feature uses pthread_setschedparam calls from pthread
-	library. Depending on the system settings, you might need to be root
-	to allow this. Please check "man 3 pthread_setschedparam" man page for
-	details
+    The PCAP play feature uses pthread_setschedparam calls from pthread
+    library. Depending on the system settings, you might need to be root
+    to allow this. Please check "man 3 pthread_setschedparam" man page for
+    details
 
 
 More details on the possible PCAP play actions can be found in the
 action reference section.
 
-.. _PCAP library: http://www.tcpdump.org/pcap3_man.html
+.. _PCAP library: https://www.tcpdump.org/manpages/pcap.3pcap.html

--- a/docs/scenarios/actions.rst
+++ b/docs/scenarios/actions.rst
@@ -542,4 +542,4 @@ on the result::
     <nop hide="true" test="authvalid" next="goodauth" />
     <nop hide="true" next="badauth" />
 
-.. _PCAP library: http://www.tcpdump.org/pcap3_man.html
+.. _PCAP library: https://www.tcpdump.org/manpages/pcap.3pcap.html

--- a/docs/scenarios/ownscenarios.rst
+++ b/docs/scenarios/ownscenarios.rst
@@ -712,7 +712,7 @@ content of headers received in the INVITE message.
 
 
 
-.. _Negative Binomial on Wikipedia: http://en.wikipedia.org/wiki/Negative_binomial_distribution
-.. _Weibull on Wikipedia: http://en.wikipedia.org/wiki/Weibull
-.. _Pareto on Wikipedia: http://en.wikipedia.org/wiki/Pareto_distribution
-.. _Gamma on Wikipedia: http://en.wikipedia.org/wiki/Gamma_distribution
+.. _Negative Binomial on Wikipedia: https://en.wikipedia.org/wiki/Negative_binomial_distribution
+.. _Weibull on Wikipedia: https://en.wikipedia.org/wiki/Weibull_distribution
+.. _Pareto on Wikipedia: https://en.wikipedia.org/wiki/Pareto_distribution
+.. _Gamma on Wikipedia: https://en.wikipedia.org/wiki/Gamma_distribution

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -9,14 +9,14 @@ JEdit
 `JEdit <http://www.jedit.org/>`_ is a GNU GPL text editor written in
 Java, and available on almost all platforms. It's extremely powerful
 and can be used to edit SIPp scenarios with syntax checking if you put
-the DTD (`sipp.dtd <http://sipp.sourceforge.net/doc/sipp.dtd>`_) in the same directory as your XML scenario.
+the DTD (`sipp.dtd <https://github.com/SIPp/sipp/raw/master/sipp.dtd>`_) in the same directory as your XML scenario.
 
 
 
 Wireshark/tshark
 ````````````````
 
-`Wireshark <http://www.wireshark.org/>`_ is a GNU GPL protocol
+`Wireshark <https://www.wireshark.org/>`_ is a GNU GPL protocol
 analyzer. It was formerly known as Ethereal. It supports SIP/SDP/RTP.
 
 
@@ -33,4 +33,4 @@ that in a graphical way: `callflow <http://callflow.sourceforge.net/>`_
 An equivalent exist if you want to generate HTML only call flows
 `http://www.iptel.org/~sipsc/`_
 
-.. _http://www.iptel.org/~sipsc/: http://www.iptel.org/~sipsc/
+.. _http://www.iptel.org/~sipsc/: https://web.archive.org/web/20120106005622/https://www.iptel.org/~sipsc/


### PR DESCRIPTION
=================
Important changes
=================

* Link to the sipp.dtd (tools.rst line 12) points to the old sourceforge-page.
  I changed it to the raw-master-version.
* Link to the iptel SIP Scenario Generator (tools.rst line 34 and 36) is not available
  since January 6, 2012
  The better link points now to https://web.archive.org with the
  SIP Scenario Generator v1.2.7 Released 25 Jul 2004 (download possible)

========================
Not so important changes
========================

* Most links are now available over HTTPS
* Add/delete lines at end of file to have only one newline at end of file
* Replace tabs with 4 whitespace characters
* Remove trailing whitespace characters

====
ToDo
====

* installation.rst line 116: SIPp compiles under CYGWIN on Windows, provided
  that you installed IPv6 extension for `CYGWIN <http://win6.jp/Cygwin/>`_, as

  This site is not available since November 1, 2016.
  Is this extension currently necessary?
  Exist an equivalent?
  If not remove the link and any related text on the website, documentation,
  build instructions, readme, setup, man-page, ...

* tools.rst line 34 and 36: http://www.iptel.org/~sipsc/ (SIP Scenario Generator)
  Now https://web.archive.org

  Is this tool still usefull?
  Can it be used with current os?
  If not remove the link and any related text on the website, documentation,
  build instructions, readme, setup, man-page, ...

Signed-off-by: hagbard-c <hagbard.github@gmx.net>

tested with: Sphinx v1.7.6