### PR TITLE
Fix to [next_url] when a display name is present in the contact

### DIFF
--- a/regress/github-#0234/uas.xml
+++ b/regress/github-#0234/uas.xml
@@ -12,7 +12,7 @@
       [last_To:];tag=[pid]SIPpTag00[call_number]
       [last_Call-ID:]
       [last_CSeq:]
-      Contact: <sip:user@1.2.3.4:58292;transport=tcp;alias=5.5.5.5~58292~2>;+sip.instance="<urn:uuid:0f35feab-c878-4622-a94e-b2e6e812b177>"
+      Contact: "Display name" <sip:user@1.2.3.4:58292;transport=tcp;alias=5.5.5.5~58292~2>;+sip.instance="<urn:uuid:0f35feab-c878-4622-a94e-b2e6e812b177>"
       Content-Length: 0
 
     ]]>

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -2763,14 +2763,14 @@ void call::formatNextReqUrl(const char* contact)
     while (*contact != '\0' && (*contact == ' ' || *contact == '\t')) {
         ++contact;
     }
-    if (*contact == '<') {
-        contact += 1;
-        const char* end = strchr(contact, '>');
-        if (end) {
-            next_req_url[0] = '\0';
-            strncat(next_req_url, contact,
-                    min(MAX_HEADER_LEN - 1, (int)(end - contact))); /* fits MAX_HEADER_LEN */
-        }
+    const char* start = strchr(contact, '<');
+    const char* end = strchr(contact, '>');
+    if ((start && end)  && (start < end)) {
+        contact = start;
+        contact++;
+        next_req_url[0] = '\0';
+        strncat(next_req_url, contact,
+                min(MAX_HEADER_LEN - 1, (int)(end - contact))); /* fits MAX_HEADER_LEN */
     } else {
         next_req_url[0] = '\0';
         strncat(next_req_url, contact, MAX_HEADER_LEN - 1);


### PR DESCRIPTION
The [next_url] Keyword didn't take into account previous contact that had a display name before the opening bracket. In these cases, the [next_url] keyword was outputting the full contact. Before issue #234, it was working correctly.