### PR TITLE
Fixed crash when exiting thread on sendto() failure

### DIFF
--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -281,9 +281,8 @@ int send_packets(play_args_t* play_args)
         }
 #endif
         if (ret < 0) {
-            close(sock);
             WARNING("send_packets.c: sendto failed with error: %s", strerror(errno));
-            return( -1);
+            break;
         }
 
         rtp_pckts_pcap++;


### PR DESCRIPTION
pthread_cleanup_pop() should be called after calling pthread_cleanup_push(), in case of sendto() failure, the function will return without calling pthread_cleanup_pop() which will cause sipp to crash with segfault.