### PR TITLE
Fix play_dtmf, rtpevent was not aligned properly

### DIFF
--- a/src/prepare_pcap.c
+++ b/src/prepare_pcap.c
@@ -298,7 +298,7 @@ struct rtphdr {
 };
 
 struct rtpevent {
-    unsigned int event_id;
+    uint8_t event_id;
 
     unsigned int volume:6;
     unsigned int reserved:1;


### PR DESCRIPTION
the rtp_events were not aligned properly (at least on my 64-bit Linux Jessie machine).
The Event ID is only 8 bits, it was put on the line as 32 bits. 