### PR TITLE
FTBFS on alpha; sipp_socklen_t set to wrong type

### DIFF
--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -187,7 +187,7 @@ struct socketbuf {
 #define WS_BUFFER 2 /* Buffer the message if there is no room for writing the message. */
 
 
-#if defined (__hpux) || defined (__alpha) && !defined (__FreeBSD__)
+#if defined (__hpux) || (defined (__alpha) && !defined (__FreeBSD__) && !defined (__linux__))
 #define sipp_socklen_t int
 #else
 #define sipp_socklen_t socklen_t


### PR DESCRIPTION
From: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=902105
Author: Michael Cree <mcree@orcon.net.nz>
Fixes: #375 

> sip-tester FTBFS on Alpha due to the sipp_socklen_t being set to int
> instead of socklen_t in the include/socket.hpp header file which
> ultimately results in the following build failure [1]:
>
> src/call.cpp: In member function 'char* call::createSendingMessage(SendingMessage*, int, char*, int, int*)':
> src/call.cpp:2153:63: error: invalid conversion from 'int*' to 'socklen_t* {aka unsigned int*}' [-fpermissive]
>                          (sockaddr *)(void *)&server_sockaddr, &len));