### PR TITLE
DocUpdate02: sphinx-build - fix malformed xml

### DIFF
--- a/docs/3PCC_extended.rst
+++ b/docs/3PCC_extended.rst
@@ -40,7 +40,7 @@ action before having any recvCmd. Note that the message must contain a
 ::
 
     <recvCmd src="m">
-      <action
+      <action>
          <ereg regexp="Content-Type:.*"
                search_in="msg"
                assign_to="2"/>

--- a/docs/int_scenarios.rst
+++ b/docs/int_scenarios.rst
@@ -260,7 +260,7 @@ the Call-ID is mandatory in order to correlate the commands to actual
 calls. In the same manner, this::
 
     <recvCmd>
-      <action
+      <action>
          <ereg regexp="Content-Type:.*"
                search_in="msg"
                assign_to="2"/>

--- a/docs/scenarios/actions.rst
+++ b/docs/scenarios/actions.rst
@@ -400,7 +400,7 @@ to find the corresponding line in users.csv.
         <ereg regexp="Digest .*username=\"([^\"]*)\"" search_in="hdr" header="Authorization:" assign_to="junk,username" />
         <lookup assign_to="line" file="users.csv" key="[$username]" />
       </action>
-    </nop>
+    </recv>
 
 
 
@@ -547,7 +547,7 @@ provided and compare it against a list of user names and passwords
 provided as an injection file, and take the appropriate action based
 on the result::
 
-    <recv request="REGISTER" />
+    <recv request="REGISTER">
       <action>
         <ereg regexp="Digest .*username=\"([^\"]*)\"" search_in="hdr" header="Authorization:" assign_to="junk,username" />
         <lookup assign_to="line" file="users.conf" key="[$username]" />

--- a/docs/scenarios/ownscenarios.rst
+++ b/docs/scenarios/ownscenarios.rst
@@ -482,7 +482,7 @@ List of commands with their attributes
         ::
 
           <recvCmd>
-            <action
+            <action>
               <ereg regexp="Content-Type:.*"
                     search_in="msg"
                     assign_to="2"/>


### PR DESCRIPTION
fix also some sphinx-build warnings:
- 3PCC_extended.rst:42: WARNING: Could not lex literal_block as "XML". Highlighting skipped.
- int_scenarios.rst:262: WARNING: Could not lex literal_block as "XML". Highlighting skipped.
- ownscenarios.rst:484: WARNING: Could not lex literal_block as "XML". Highlighting skipped.