### PR TITLE
fixed compiling bug on cygwin

### DIFF
--- a/include/sip_parser.hpp
+++ b/include/sip_parser.hpp
@@ -23,6 +23,9 @@
 #ifndef __SIPP_SIP_PARSER_H__
 #define __SIPP_SIP_PARSER_H__
 
+#include <ctype.h>
+#include <string.h>
+
 #define MAX_HEADER_LEN 2049
 
 char *get_call_id(const char* msg);

--- a/src/sip_parser.cpp
+++ b/src/sip_parser.cpp
@@ -160,7 +160,7 @@ char* get_header(const char* message, const char* name, bool content)
         snprintf(header_with_newline, MAX_HEADER_LEN, "\n%s", name);
         dest = last_header;
 
-        while ((src = strcasestr(src, header_with_newline))) {
+        while ((src = strstr(src, header_with_newline))) {
             if (content || !first_time) {
                 /* Just want the header's content, so skip over the header
                  * and newline */

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 #include "sipp.hpp"
 #include "socket.hpp"
 #include "logger.hpp"
@@ -755,9 +756,9 @@ int SIPpSocket::check_for_message()
     socketbuf->buf[socketbuf->offset + len] = '\0';
 
     /* Find the content-length header. */
-    if ((l = strcasestr(socketbuf->buf + socketbuf->offset, "\r\nContent-Length:"))) {
+    if ((l = strstr(socketbuf->buf + socketbuf->offset, "\r\nContent-Length:"))) {
         l += strlen("\r\nContent-Length:");
-    } else if ((l = strcasestr(socketbuf->buf + socketbuf->offset, "\r\nl:"))) {
+    } else if ((l = strstr(socketbuf->buf + socketbuf->offset, "\r\nl:"))) {
         l += strlen("\r\nl:");
     }
 


### PR DESCRIPTION
I get follow error:
src/socket.cpp:758:14: error: ‘strcasestr’ was not declared in this scope
     if ((l = strcasestr(socketbuf->buf + socketbuf->offset, "\r\nContent-Length:"))) {
              ^~~~~~~~~~
src/socket.cpp:758:14: note: suggested alternative: ‘strcasecmp’
     if ((l = strcasestr(socketbuf->buf + socketbuf->offset, "\r\nContent-Length:"))) {
              ^~~~~~~~~~
              strcasecmp