### PR TITLE
Fixed warnings generated by GCC 9

### DIFF
--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -230,7 +230,7 @@ MAYBE_EXTERN int                max_sched_loops         DEFVAL(MAX_SCHED_LOOPS_P
 MAYBE_EXTERN unsigned int       global_t2               DEFVAL(DEFAULT_T2_TIMER_VALUE);
 
 MAYBE_EXTERN char               local_ip[127];          /* also used for hostnames */
-MAYBE_EXTERN char               local_ip_escaped[42];   /* with [brackets] in case of IPv6 */
+MAYBE_EXTERN char               local_ip_escaped[129];  /* with [brackets] in case of IPv6 */
 MAYBE_EXTERN bool               local_ip_is_ipv6;
 MAYBE_EXTERN int                local_port              DEFVAL(0);
 #ifdef USE_SCTP
@@ -261,7 +261,7 @@ MAYBE_EXTERN int                media_port              DEFVAL(0);
 MAYBE_EXTERN size_t             media_bufsize           DEFVAL(2048);
 MAYBE_EXTERN bool               media_ip_is_ipv6        DEFVAL(false);
 MAYBE_EXTERN char               remote_ip[127];         /* also used for hostnames */
-MAYBE_EXTERN char               remote_ip_escaped[42];  /* with [brackets] in case of IPv6 */
+MAYBE_EXTERN char               remote_ip_escaped[129]; /* with [brackets] in case of IPv6 */
 MAYBE_EXTERN int                remote_port             DEFVAL(DEFAULT_PORT);
 MAYBE_EXTERN unsigned int       pid                     DEFVAL(0);
 MAYBE_EXTERN bool               print_all_responses     DEFVAL(false);

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -328,8 +328,8 @@ int createAuthHeaderMD5(const char *user,
 {
 
     unsigned char resp_hex[HASH_HEX_SIZE+1];
-    char tmp[MAX_HEADER_LEN],
-        tmp2[MAX_HEADER_LEN],
+    char tmp[MAX_HEADER_LEN + 8],
+        tmp2[MAX_HEADER_LEN + 64],
         realm[MAX_HEADER_LEN],
         sipuri[MAX_HEADER_LEN],
         nonce[MAX_HEADER_LEN],

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -681,19 +681,19 @@ void call::dump()
     char tmpbuf[MAX_HEADER_LEN];
     sprintf(s, "%s: State %d", id, msg_index);
     if (next_retrans) {
-        snprintf(tmpbuf, 64, "%s (next retrans %u)", s, next_retrans);
+        snprintf(tmpbuf, 2073, "%s (next retrans %u)", s, next_retrans);
         strcat(s, tmpbuf);
     }
     if (paused_until) {
-        snprintf(tmpbuf, 64, "%s (paused until %u)", s, paused_until);
+        snprintf(tmpbuf, 2073, "%s (paused until %u)", s, paused_until);
         strcat(s, tmpbuf);
     }
     if (recv_timeout) {
-        snprintf(tmpbuf, 64, "%s (recv timeout %u)", s, recv_timeout);
+        snprintf(tmpbuf, 2073, "%s (recv timeout %u)", s, recv_timeout);
         strcat(s, tmpbuf);
     }
     if (send_timeout) {
-        snprintf(tmpbuf, 64, "%s (send timeout %u)", s, send_timeout);
+        snprintf(tmpbuf, 2073, "%s (send timeout %u)", s, send_timeout);
         strcat(s, tmpbuf);
     }
     WARNING("%s", s);


### PR DESCRIPTION
Warning like this
```
src/socket.cpp:2363:46: warning: ‘%s’ directive writing up to 126 bytes into a region of size 41 [-Wformat-overflow=]
 2363 |                 sprintf(remote_ip_escaped, "[%s]", remote_ip);
      |                                              ^~    ~~~~~~~~~
src/socket.cpp:2363:24: note: ‘sprintf’ output between 3 and 129 bytes into a destination of size 42
 2363 |                 sprintf(remote_ip_escaped, "[%s]", remote_ip);
      |                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/socket.cpp:2440:41: warning: ‘%s’ directive writing up to 126 bytes into a region of size 41 [-Wformat-overflow=]
 2440 |             sprintf(local_ip_escaped, "[%s]", local_ip);
      |                                         ^~    ~~~~~~~~
src/socket.cpp:2440:20: note: ‘sprintf’ output between 3 and 129 bytes into a destination of size 42
 2440 |             sprintf(local_ip_escaped, "[%s]", local_ip);
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/socket.cpp:2440:41: warning: ‘%s’ directive writing up to 126 bytes into a region of size 41 [-Wformat-overflow=]
 2440 |             sprintf(local_ip_escaped, "[%s]", local_ip);
      |                                         ^~    ~~~~~~~~
src/socket.cpp:2440:20: note: ‘sprintf’ output between 3 and 129 bytes into a destination of size 42
 2440 |             sprintf(local_ip_escaped, "[%s]", local_ip);
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```