### PR TITLE
New feature : 'chance_variable' attribute

### DIFF
--- a/docs/scenarios/cond_branching.rst
+++ b/docs/scenarios/cond_branching.rst
@@ -52,7 +52,8 @@ To have SIPp behave somewhat more like a "normal" SIP client being
 used by a human, it is possible to use "statistical branching".
 Wherever you can have a conditional branch on a variable being set
 (test="4"), you can also branch based on a statistical decision using
-the attribute "chance" (e.g. chance="0.90"). Chance can have a value
+the attribute "chance" (e.g. chance="0.90") or "chance_variable"
+(e.g. chance_variable="probaSuccess"). Chance can have a value
 between 0 (never) and 1 (always). "test" and "chance" can be combined,
 i.e. only branching when the test succeeds and the chance is good.
 

--- a/docs/scenarios/ownscenarios.rst
+++ b/docs/scenarios/ownscenarios.rst
@@ -155,6 +155,19 @@ List of attributes common to all commands
 
         90% chance to go to label "5" if variable "3" is set.
 
+        * - ``chance_variable``
+          - In combination with "test", set the variable used to define the
+            probability to actually branch to another part of the scenario.
+            The set variable can have a value between 0(never) and 1 (always).
+            See conditional branching section for more info.
+
+          - ::
+
+              <recv response="403" optional="true" next="5" test="3" chance_variable="branchingProba">
+              </recv>
+
+            90% chance to go to label "5" if variable "3" is set.
+
     * - ``condexec``
       - Executes an element only if the variable in the condexec attribute is
         set. This attribute allows you to write complex XML scenarios with

--- a/include/scenario.hpp
+++ b/include/scenario.hpp
@@ -114,6 +114,7 @@ public:
     int            condexec;
     bool           condexec_inverse;
     int            chance;/* 0=always, RAND_MAX+1=never (test rand() >= chance) */
+    int            chance_variable;
     int            on_timeout;
     char *         onTimeoutLabel;
 

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -1212,6 +1212,11 @@ bool call::next()
              M_callVariableTable->getVar(test)->isSet())) {
         /* Branching possible, check the probability */
         int chance = (*msgs)[msg_index]->chance;
+        /* If no "chance" but "chance_variable" set */
+        if(chance==0 && (*msgs)[msg_index]->chance_variable>-1) {
+          double v_chance = M_callVariableTable->getVar((*msgs)[msg_index]->chance_variable)->getDouble();
+          chance=(int)((1.0-v_chance)*RAND_MAX);
+        }
         if ((chance <= 0) || (rand() > chance )) {
             /* Branch == overwrite with the 'next' attribute value */
             new_msg_index = (*msgs)[msg_index]->next;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -72,6 +72,7 @@ message::message(int index, const char *desc)
     condexec = -1;
     condexec_inverse = false;
     chance = 0;/* meaning always */
+    chance_variable = -1;
     next = -1;
     nextLabel = NULL; // free on exit
     on_timeout = -1;
@@ -1780,6 +1781,7 @@ void scenario::getCommonAttributes(message *message)
 
     message -> condexec = xp_get_var("condexec", "condexec variable", -1);
     message -> condexec_inverse = xp_get_bool("condexec_inverse", "condexec_inverse", false);
+    message -> chance_variable = xp_get_var("chance_variable", "chance_variable", -1);
 
     if ((ptr = xp_get_value("next"))) {
         if (found_timewait) {


### PR DESCRIPTION
The purpose of this new feature is to use a double variable to define set the probability.

example : 
```xml
<nop>
    <action>
        <assign assign_to="pExec" variable="hangup" />
        <multiply assign_to="pExec" variable="errors" />  <!-- $pExec = $hangup * $errors -->
    </action>
</nop>

<recv response="180" chance_variable="pExec" next="2"/>
```