### PR TITLE
Increment nonce count and get auth method from message being sent.

### DIFF
--- a/include/auth.hpp
+++ b/include/auth.hpp
@@ -23,6 +23,7 @@ int createAuthHeader(const char *user,
                      const char *aka_OP,
                      const char *aka_AMF,
                      const char *aka_K,
+                     unsigned int nonce_count,
                      char *result);
 int verifyAuthHeader(const char *user, const char *password,
                      const char *method, const char *auth,

--- a/include/call.hpp
+++ b/include/call.hpp
@@ -177,6 +177,8 @@ protected:
     char         * dialog_authentication;
     int            dialog_challenge_type;
 
+    unsigned int   next_nonce_count;
+
     unsigned int   next_retrans;
     int            nb_retrans;
     unsigned int   nb_last_delay;


### PR DESCRIPTION
Hello.

I'm trying to address two digest authentication issues I've encountered while executing several of my scenarios.

1.) SIPp currently doesn't support incrementing the nonce count to keep an ongoing authenticated call alive without being re-challenged on every request. In several of my scenarios, this was resulting in undesired challenges. The nonce count changes are based on an old patch I found here:

https://sipp-users.narkive.com/6Gl681EP/patch-to-correctly-increment-nc-in-authorization-header

2.) In some of my scenarios which mix different SIP request methods, I was having some unexpected authentication failures. I tracked it down to the method being used to generate the auth hashes not matching the method of the message being sent.

The old way of getting the auth method from the CSeq of the last header would fail if the previous message sent was a different method than the current message being sent. It seems simple and safe to just use the method of the message being sent when generating the auth hashes.

Thanks for the consideration.