### PR TITLE
Added feature to display listing for code validation

### DIFF
--- a/validate-src.sh
+++ b/validate-src.sh
@@ -1,14 +1,29 @@
 #!/bin/sh
+
+print_listing=false
 err=0
 TAB=`printf '\t'`
+
+while getopts ':l' opt
+do
+case $opt in
+l) print_listing=true;;
+esac
+done
 
 files_with_tabs=`\
     find include src '!' -name config.h \
       '(' -name '*.cpp' -o -name '*.hpp' -o -name '*.c' -o -name '*.h' ')' |
-    xargs grep -l "$TAB" | sed -e 's/^/  /'`
+    xargs grep -l "$TAB"`
 if test -n "$files_with_tabs"; then
     echo "tabs encountered in one or more source files:" >&2
-    echo "$files_with_tabs" >&2
+    for file in $files_with_tabs; do
+        echo "  $file" >&2
+        if $print_listing; then
+            listing=`grep -n "$TAB" $file | sed -e 's/^/    /'`
+            echo "$listing" >&2
+        fi
+    done
     echo >&2
     err=$((err+1))
 fi
@@ -16,10 +31,16 @@ fi
 files_with_trailing_ws=`\
     find include src '!' -name config.h \
       '(' -name '*.cpp' -o -name '*.hpp' -o -name '*.c' -o -name '*.h' ')' |
-    xargs grep -l '[[:blank:][:cntrl:]]$' | sed -e 's/^/  /'`
+    xargs grep -l '[[:blank:][:cntrl:]]$'`
 if test -n "$files_with_trailing_ws"; then
     echo "trailing whitespace found in one or more source files:" >&2
-    echo "$files_with_trailing_ws" >&2
+    for file in $files_with_trailing_ws; do
+        echo "  $files_with_trailing_ws" >&2
+        if $print_listing; then
+            listing=`grep -n '[[:blank:][:cntrl:]]$' $file | sed -e 's/^/    /'`
+            echo "$listing" >&2
+        fi
+    done
     echo >&2
     err=$((err+1))
 fi
@@ -27,10 +48,16 @@ fi
 files_with_not_4_spaces=`\
     find include src '!' -name config.h \
       '(' -name '*.cpp' -o -name '*.hpp' -o -name '*.c' -o -name '*.h' ')' |
-    xargs grep -lE '^(  \}| {1,3}[a-z_])' | sed -e 's/^/  /'`
+    xargs grep -lE '^(  \}| {1,3}[a-z_])'`
 if test -n "$files_with_not_4_spaces"; then
     echo "files with non-standard indentation found:" >&2
-    echo "$files_with_not_4_spaces" >&2
+    for file in $files_with_not_4_spaces; do
+        echo "  $file" >&2
+        if $print_listing; then
+            listing=`grep -nE '^(  \}| {1,3}[a-z_])' $file | sed -e 's/^/    /'`
+            echo "$listing" >&2
+        fi
+    done
     echo >&2
     err=$((err+1))
 fi


### PR DESCRIPTION
Added flag `-l` for print code listring.  
Without this, it was difficult to find what the validator considers to be an error.  
Example:
```
dolk13@Lumos:~/projects/sipp$ ./validate-src.sh -l
trailing whitespace found in one or more source files:
  src/sipp.cpp
    454:    char L_file_name[MAX_PATH];   

files with non-standard indentation found:
  src/call.cpp
    3719:  default:
    3720:  return(call::E_AR_STOP_CALL);
```
