### PR TITLE
Socket: Reorder abort operations on read/write error

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1872,8 +1872,8 @@ int SIPpSocket::write_error(int ret)
     if ((ss_transport == T_TCP || ss_transport == T_SCTP)
             && errno == EPIPE) {
         nb_net_send_errors++;
-        abort();
         sockets_pending_reset.insert(this);
+        abort();
         if (reconnect_allowed()) {
             WARNING("Broken pipe on TCP connection, remote peer "
                     "probably closed the socket");
@@ -1962,8 +1962,8 @@ int SIPpSocket::read_error(int ret)
             return 0;
         }
 
-        abort();
         sockets_pending_reset.insert(this);
+        abort();
 
         nb_net_recv_errors++;
         if (reconnect_allowed()) {


### PR DESCRIPTION
In 7c7c713971193a83399be71fe129b0f9c5f8864c the order of abort() and
sockets_pending_reset.insert(socket) was changed. Starting from this
commit, abort() is called before inserting to the list.

If the refcount drops to 0, the socket erases itself from the list (in
which it still was not inserted), and then deletes itself. After that,
the deleted socket is inserted to the list.

Fixed by reverting to the original order.