### PR TITLE
Call: Add a missing socket refcount on TCP

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -764,6 +764,7 @@ bool call::connect_socket_if_needed()
         if ((associate_socket(SIPpSocket::new_sipp_call_socket(use_ipv6, transport, &existing))) == NULL) {
             ERROR_NO("Unable to get a TCP/SCTP/TLS socket");
         }
+        call_socket->ss_count++;
 
         if (existing) {
             return true;


### PR DESCRIPTION
On read/write error the socket calls abort(), which deletes it while it
is still referenced by the call.