### PR TITLE
Should not access SDP body when 'Content-Length: 0'

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -2822,7 +2822,10 @@ bool call::process_incoming(const char* msg, const struct sockaddr_storage* src)
     /* Check if message has a SDP in it; and extract media information. */
     if (!strcmp(get_header_content(msg, "Content-Type:"), "application/sdp") &&
             hasMedia == 1 && !curmsg->ignoresdp) {
-        extract_rtp_remote_addr(msg);
+        const char* ptr = get_header_content(msg, "Content-Length:");
+        if (ptr && atoll(ptr) > 0) {
+            extract_rtp_remote_addr(msg);
+        }
     }
 #endif
 


### PR DESCRIPTION
The call::process_incoming() emit error message when 'Content-Type: application/sdp' is presented but 'Content-Length: 0'. Shouldn't try to access the SDP body for this situation.