### PR TITLE
Consistently unescape XML attributes when loading scenario

### DIFF
--- a/regress/github-#0458/run
+++ b/regress/github-#0458/run
@@ -1,0 +1,22 @@
+#!/bin/sh
+# This regression test is a part of SIPp.
+. "`dirname "$0"`/../functions"; init
+
+sippfg -m 1 -sf uas.xml -p 5070 >/dev/null 2>&1 &
+job=$!
+
+sippfg -m 1 -sf uac.xml 127.0.0.1:5070 \
+    -trace_err -error_file err.log \
+    -timeout 4 -timeout_error >/dev/null 2>&1
+status=$?
+wait $job || status=1
+
+if test $status -eq 0; then
+    ok
+else
+    if grep -q 'Matching Error' err.log; then
+        fail "matching error - escaping?"
+    else
+        fail "unknown failure"
+    fi
+fi

--- a/regress/github-#0458/uac.xml
+++ b/regress/github-#0458/uac.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <send retrans="500" start_txn="invite">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: "Tom Jones" <sip:tom.jones@wales.uk>;tag=[pid]SIPpTag00[call_number]
+      To: "Fromage" <sip:cheese@paris.fr>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv response="404" response_txn="invite">
+    <action>
+      <ereg regexp="(&quot;[^&quot;]*&quot; &lt;[^&gt;]*&gt;)" search_in="hdr" header="To:" assign_to="var"/>
+    </action>
+  </recv>
+  <Reference variables="var"/>
+
+  <send ack_txn="invite">
+    <![CDATA[
+
+      ACK [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      [routes]
+      From: sip:[service]@[local_ip]:[local_port];tag=[pid]SIPpTag00[call_number]
+      To: sip:[service]@[remote_ip]:[remote_port][peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: [cseq] ACK
+      Contact: sip:[service]@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!--
+    If attribute escaping handling is correct in the scenario loading, then the
+    test below will work. If it doesn't, then it will fail because of the XML
+    entities.
+  -->
+  <nop>
+    <action>
+      <strcmp assign_to="1" variable="var" value="&quot;Fromage&quot; &lt;sip:cheese@paris.fr&gt;"/>
+      <test assign_to="result" variable="1" compare="equal" value="0" /> <!-- If strcmp is successful, it returns 0 -->
+    </action>
+  </nop>
+
+  <nop condexec="result" condexec_inverse="true">
+    <action>
+      <warning message="Matching Error: '[$var]' != '&quot;Fromage&quot; &lt;sip:cheese@paris.fr&gt;'"/>
+      <exec int_cmd="stop_now" />
+    </action>
+  </nop>
+
+  <timewait milliseconds="500"/>
+</scenario>

--- a/regress/github-#0458/uas.xml
+++ b/regress/github-#0458/uas.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario>
+  <recv request="INVITE"/>
+
+  <send retrans="500">
+    <![CDATA[
+      SIP/2.0 404 Not Found
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag00[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <recv request="ACK"/>
+
+  <timewait milliseconds="500"/>
+</scenario>


### PR DESCRIPTION
This changes the behaviour of `xp_get_string()` in order to
systematically unescape the returned values, as other XML parsers do.
The custom unescaping in the handling of the `<ereg>` element has been
removed as it is now unneeded.

This will make it possible to e.g. compare strings that contain special
XML characters using `<strcmp>`.

A regression test case has been added to highlight the problem.

https://github.com/SIPp/sipp/issues/458