### PR TITLE
Allow the get_header function to accept a mix of regular and compact headers when performing lookups.

### DIFF
--- a/include/sip_parser.hpp
+++ b/include/sip_parser.hpp
@@ -34,6 +34,7 @@ unsigned long get_reply_code(const char* msg);
 
 char *get_header_content(const char* message, const char* name);
 char *get_header(const char* message, const char* name, bool content);
+char* match_header(char* message, char* header, char* compact_header);
 const char* get_short_header_name(const char* name);
 char *get_first_line(const char* message);
 

--- a/include/sip_parser.hpp
+++ b/include/sip_parser.hpp
@@ -35,7 +35,7 @@ unsigned long get_reply_code(const char* msg);
 char *get_header_content(const char* message, const char* name);
 char *get_header(const char* message, const char* name, bool content);
 char* match_header(char* message, char* header, char* compact_header);
-const char* get_short_header_name(const char* name);
+const char* get_compact_header_name(const char* name);
 char *get_first_line(const char* message);
 
 #endif /* __SIPP_SIP_PARSER_H__ */

--- a/include/sip_parser.hpp
+++ b/include/sip_parser.hpp
@@ -24,6 +24,7 @@
 #define __SIPP_SIP_PARSER_H__
 
 #define MAX_HEADER_LEN 2049
+#define MAX_COMPACT_HEADER_LEN 2
 
 char *get_call_id(const char* msg);
 char *get_peer_tag(const char* msg);
@@ -35,7 +36,7 @@ unsigned long get_reply_code(const char* msg);
 char *get_header_content(const char* message, const char* name);
 char *get_header(const char* message, const char* name, bool content);
 char* match_header(char* message, char* header, char* compact_header);
-const char* get_compact_header_name(const char* name);
+char* get_compact_header_name(const char* name);
 char *get_first_line(const char* message);
 
 #endif /* __SIPP_SIP_PARSER_H__ */

--- a/include/sip_parser.hpp
+++ b/include/sip_parser.hpp
@@ -34,6 +34,7 @@ unsigned long get_reply_code(const char* msg);
 
 char *get_header_content(const char* message, const char* name);
 char *get_header(const char* message, const char* name, bool content);
+const char* get_short_header_name(const char* name);
 char *get_first_line(const char* message);
 
 #endif /* __SIPP_SIP_PARSER_H__ */

--- a/src/sip_parser.cpp
+++ b/src/sip_parser.cpp
@@ -220,24 +220,8 @@ char* get_header(const char* message, const char* name, bool content)
 
         /* We should retry with the short form. */
         short_form = true;
-        if (!strcasecmp(name, "call-id:")) {
-            name = "i:";
-        } else if (!strcasecmp(name, "contact:")) {
-            name = "m:";
-        } else if (!strcasecmp(name, "content-encoding:")) {
-            name = "e:";
-        } else if (!strcasecmp(name, "content-length:")) {
-            name = "l:";
-        } else if (!strcasecmp(name, "content-type:")) {
-            name = "c:";
-        } else if (!strcasecmp(name, "from:")) {
-            name = "f:";
-        } else if (!strcasecmp(name, "to:")) {
-            name = "t:";
-        } else if (!strcasecmp(name, "via:")) {
-            name = "v:";
-        } else {
-            /* There is no short form to try. */
+        name = get_short_header_name(name);
+        if (strlen(name) == 0) {
             free(src_orig);
             return last_header;
         }
@@ -273,6 +257,33 @@ char* get_header(const char* message, const char* name, bool content)
 
     free(src_orig);
     return start;
+}
+
+const char* get_short_header_name(const char* name)
+{
+    const char* short_name = "";
+
+    if (!strcasecmp(name, "call-id:")) {
+        short_name = "i:";
+    } else if (!strcasecmp(name, "contact:")) {
+        short_name = "m:";
+    } else if (!strcasecmp(name, "content-encoding:")) {
+        short_name = "e:";
+    } else if (!strcasecmp(name, "content-length:")) {
+        short_name = "l:";
+    } else if (!strcasecmp(name, "content-type:")) {
+        short_name = "c:";
+    } else if (!strcasecmp(name, "from:")) {
+        short_name = "f:";
+    } else if (!strcasecmp(name, "to:")) {
+        short_name = "t:";
+    } else if (!strcasecmp(name, "via:")) {
+        short_name = "v:";
+    } else {
+        short_name = "";
+    }
+
+    return short_name;
 }
 
 char* get_first_line(const char* message)

--- a/src/sip_parser.cpp
+++ b/src/sip_parser.cpp
@@ -129,7 +129,7 @@ char* get_header(const char* message, const char* name, bool content)
     bool first_time = true;
     char header_with_newline[MAX_HEADER_LEN + 1];
 
-    const char* compact_name = get_short_header_name(name);
+    const char* compact_name = get_compact_header_name(name);
     char compact_header_with_newline[MAX_HEADER_LEN + 1];
 
     /* returns empty string in case of error */
@@ -272,31 +272,31 @@ char* get_header(const char* message, const char* name, bool content)
 
 char* match_header(char* message, char* header, char* compact_header) {
     // Attempt to find the header
-    char* r = strcasestr(message, header);
+    char* header_match = strcasestr(message, header);
     if (strlen(compact_header) < 2) {
-        // Exit when there is no compact header with the result of r.
-        return r;
+        // Exit when there is no compact header to compare to
+        return header_match;
     }
 
-    char* r2 = strcasestr(message, compact_header);
+    char* compact_header_match = strcasestr(message, compact_header);
 
     // Return the other if one is null
-    if (r == nullptr) {
-        return r2;
+    if (header_match == nullptr) {
+        return compact_header_match;
     }
-    if (r2 == nullptr) {
-        return r;
-    }
-
-    // Value exists return the smaller if the two:
-    if (r < r2) {
-        return r;
+    if (compact_header_match == nullptr) {
+        return header_match;
     }
 
-    return r2;
+    // Value exists return the smaller of the two.
+    if (header_match < compact_header_match) {
+        return header_match;
+    }
+
+    return compact_header_match;
 }
 
-const char* get_short_header_name(const char* name)
+const char* get_compact_header_name(const char* name)
 {
     const char* short_name = "";
 
@@ -726,7 +726,9 @@ TEST(Parser, get_call_id_short_2) {
 }
 
 TEST(Parser, get_short_header_via) {
-    EXPECT_STREQ("v:", get_short_header_name("Via:"));
+    EXPECT_STREQ("v:", get_compact_header_name("Via:"));
+
+    EXPECT_STREQ("m:", get_compact_header_name("Contact:"));
 }
 
 /* The 3pcc-A script sends "invalid" SIP that is parsed by this

--- a/src/sip_parser.cpp
+++ b/src/sip_parser.cpp
@@ -296,28 +296,28 @@ char* match_header(char* message, char* header, char* compact_header) {
     return compact_header_match;
 }
 
-const char* get_compact_header_name(const char* name)
+char* get_compact_header_name(const char* name)
 {
-    const char* short_name = "";
+    static char short_name[MAX_COMPACT_HEADER_LEN];
 
     if (!strcasecmp(name, "call-id:")) {
-        short_name = "i:";
+        sprintf(short_name, "i:");
     } else if (!strcasecmp(name, "contact:")) {
-        short_name = "m:";
+        sprintf(short_name, "m:");
     } else if (!strcasecmp(name, "content-encoding:")) {
-        short_name = "e:";
+        sprintf(short_name, "e:");
     } else if (!strcasecmp(name, "content-length:")) {
-        short_name = "l:";
+        sprintf(short_name, "l:");
     } else if (!strcasecmp(name, "content-type:")) {
-        short_name = "c:";
+        sprintf(short_name, "c:");
     } else if (!strcasecmp(name, "from:")) {
-        short_name = "f:";
+        sprintf(short_name, "f:");
     } else if (!strcasecmp(name, "to:")) {
-        short_name = "t:";
+        sprintf(short_name, "t:");
     } else if (!strcasecmp(name, "via:")) {
-        short_name = "v:";
+        sprintf(short_name, "v:");
     } else {
-        short_name = "";
+        sprintf(short_name, "");
     }
 
     return short_name;
@@ -623,8 +623,6 @@ a=rtcp:41605\r\n\
 }
 
 TEST(Parser, get_header_mixed_form) {
-    /* If you remove the CR ("\r") from any header before the Call-ID,
-     * the Call-ID will not be found. */
     const char* data = "INVITE sip:3136455552@85.12.1.1:5065 SIP/2.0\r\n\
 v: SIP/2.0/UDP 85.55.55.12:6090;branch=z9hG4bK831a.2bb3de85.0\r\n\
 Via: SIP/2.0/UDP 85.55.55.12:5090;branch=z9hG4bK831a.2bb3de85.0\r\n\
@@ -668,9 +666,19 @@ SIP/2.0/UDP 85.55.55.12:5060;branch=z9hG4bK831a.2bb3de87.0, \
 SIP/2.0/UDP 85.55.55.12:4060;branch=z9hG4bK831a.2bb3de86.0, \
 SIP/2.0/UDP 85.55.55.12:4050;branch=z9hG4bK831a.2bb3de86.0", get_header(data, "Via:", false));
 
+    EXPECT_STREQ("SIP/2.0/UDP 85.55.55.12:6090;branch=z9hG4bK831a.2bb3de85.0, \
+SIP/2.0/UDP 85.55.55.12:5090;branch=z9hG4bK831a.2bb3de85.0, \
+SIP/2.0/UDP 85.55.55.12:5060;branch=z9hG4bK831a.2bb3de87.0, \
+SIP/2.0/UDP 85.55.55.12:4060;branch=z9hG4bK831a.2bb3de86.0, \
+SIP/2.0/UDP 85.55.55.12:4050;branch=z9hG4bK831a.2bb3de86.0", get_header(data, "Via:", true));
+
     EXPECT_STREQ("Record-Route: <sip:85.55.55.12:5090;r2=on;lr>, \
 <sip:10.231.33.44;r2=on;lr>, \
 <sip:10.231.33.77;lr=on>", get_header(data, "Record-Route:", false));
+
+    EXPECT_STREQ("<sip:85.55.55.12:5090;r2=on;lr>, \
+<sip:10.231.33.44;r2=on;lr>, \
+<sip:10.231.33.77;lr=on>", get_header(data, "Record-Route:", true));
 
     EXPECT_STREQ("<sip:12999999999@85.55.55.12;did=a19.a2e590e>", get_header(data, "Contact:", true));
 }


### PR DESCRIPTION
**Issue**: #13 

**Proposed Changes**:
This changeset modifies the get_header function to accept a mix of regular and compact headers when performing retrievals of headers. This is particularly useful when SIP packets have a mix of the two types as is the case in the SIP packet used in the test case.