### PR TITLE
fix cmake  build error if PROJECT_SOURCE_DIR is not  same with PROJEC…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ file(WRITE ${PROJECT_SOURCE_DIR}/include/version.cmake
 ")
 add_custom_target(
     version
-    if test -d .git \; then
+    if test -d ${PROJECT_SOURCE_DIR}/.git \; then
         ${CMAKE_COMMAND} -D SRC=${PROJECT_SOURCE_DIR}/include/version.h.in
         -D DST=${PROJECT_BINARY_DIR}/version.h
         -P ${PROJECT_SOURCE_DIR}/include/version.cmake \;


### PR DESCRIPTION
build error like this:

> sipp/include/version.h:3:2: error: "  This is a stub version.h. You should not use this fake version number, but a git-tagged version instead. You should download the proper .tar.gz which
      includes a proper version.h or clone the SIPp repository using git."
#error "\
 ^
sipp/src/call.cpp:3897:61: error: use of undeclared identifier 'VERSION'
            dest += snprintf(dest, left, "%s", (const char*)VERSION + 1);