### PR TITLE
Fix a segmentation fault in 'call.cpp:2369: createAuthHeader'

### DIFF
--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -273,8 +273,10 @@ static int createAuthResponseMD5(
 
     // Load in A2
     md5_init(&Md5Ctx);
-    md5_append(&Md5Ctx, (md5_byte_t *) method, strlen(method));
-    md5_append(&Md5Ctx, (md5_byte_t *) ":", 1);
+    if (method) {
+        md5_append(&Md5Ctx, (md5_byte_t *) method, strlen(method));
+        md5_append(&Md5Ctx, (md5_byte_t *) ":", 1);
+    }
     md5_append(&Md5Ctx, (md5_byte_t *) tmp, strlen(tmp));
     if (stristr(authtype, "auth-int") != NULL) {
         md5_append(&Md5Ctx, (md5_byte_t *) ":", 1);


### PR DESCRIPTION
The SegFault only happens if the SIPp reference to the authentication header (in our case [field2], see the attached 'fail.xml') is used (in the example 'fail.xml': echo [field2]) after or in the receive section of the REGISTER message which actually sends the authentication header. In this case "getMethod" returns 0x0 (see 'gdb.txt', also attached).
It was introduced by commit 6dd80fe by using the function 'src->getMethod()' instead of the variable 'method'.

[fix_info.tar.gz](https://github.com/SIPp/sipp/files/5775910/fix_info.tar.gz)
