### PR TITLE
Fix for rtp_stream IPv6 media

### DIFF
--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -1277,30 +1277,30 @@ static void setup_media_sockets()
 
     // assert that an IPv6 'media_ip' is not surrounded by brackets?
     //
+    hints.ai_flags  = AI_PASSIVE;
+    hints.ai_family = PF_UNSPEC; /* use local_ip_is_ipv6 as hint? */
+
+    /* Resolving local IP */
+    if (getaddrinfo(media_ip,
+                    NULL,
+                    &hints,
+                    &local_addr) != 0) {
+        ERROR("Unknown RTP address '%s'.\n"
+              "Use 'sipp -h' for details", media_ip);
+    }
+    memcpy(&media_sockaddr, local_addr->ai_addr, socklen_from_addr(_RCAST(struct sockaddr_storage*, local_addr->ai_addr)));
+    freeaddrinfo(local_addr);
+
+    media_ip_is_ipv6 = (media_sockaddr.ss_family == AF_INET6);
+
+    media_socket_audio = -1;
+    media_socket_video = -1;
+
 #ifdef RTP_STREAM
     if ((user_media_port > 0) && rtp_echo_enabled) {
 #else
     if (1) {
 #endif // RTP_STREAM
-        hints.ai_flags  = AI_PASSIVE;
-        hints.ai_family = PF_UNSPEC; /* use local_ip_is_ipv6 as hint? */
-
-        /* Resolving local IP */
-        if (getaddrinfo(media_ip,
-                        NULL,
-                        &hints,
-                        &local_addr) != 0) {
-            ERROR("Unknown RTP address '%s'.\n"
-                  "Use 'sipp -h' for details", media_ip);
-        }
-        memcpy(&media_sockaddr, local_addr->ai_addr, socklen_from_addr(_RCAST(struct sockaddr_storage*, local_addr->ai_addr)));
-        freeaddrinfo(local_addr);
-
-        media_ip_is_ipv6 = (media_sockaddr.ss_family == AF_INET6);
-
-        media_socket_audio = -1;
-        media_socket_video = -1;
-
         for (try_counter = 1; try_counter <= max_tries; try_counter++) {
             last_attempt = (try_counter == max_tries);
 


### PR DESCRIPTION
I tested IPv6 media with an rtp_stream UAC and rtp_echo UAS. I got the following errors:
```
The following events occurred:
2021-03-11      15:48:49.304703 1615470529.304703: Could not set up media IP for RTP streaming
2021-03-11      15:48:49.305049 1615470529.305049: cannot assign a free audio port to this call - using 0 for [rtpstream_audio_port]
```

After debugging a bit I've noticed that the following line never got called, in ```src/sipp.cpp```:
```
        media_ip_is_ipv6 = (media_sockaddr.ss_family == AF_INET6);
```
... because below condition was always false:
```
#ifdef RTP_STREAM
    if ((user_media_port > 0) && rtp_echo_enabled) {
#else
```

Tested changes locally, and IPv6 media works after this commit. Maybe @jeannotlanglois can give some feedbak for this PR.

Thank you,
Stefan