### PR TITLE
CMake: Bump minimum version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # set the project name
 project(SIPp)


### PR DESCRIPTION
2.8 is deprecated.