### PR TITLE
Add URL encode/decode <action> for scenarios.

### DIFF
--- a/docs/scenarios/actions.rst
+++ b/docs/scenarios/actions.rst
@@ -482,6 +482,24 @@ and microseconds since the epoch. For example::
 
 
 
+urlencode / urldecode
++++++++++++++++++++++
+
+The urlencode and urldecode actions will replace the content of the
+variable specified in variable with the coded version. For example::
+
+Content of variable_to_be_encoded is "this: is a string".
+
+    <nop>
+      <action>
+        <urlencode variable="variable_to_be_encoded" />
+      </action>
+    </nop>
+
+Content of variable_to_be_encoded now is "this%3A%20is%20a%20string".
+
+
+
 setdest
 +++++++
 

--- a/include/actions.hpp
+++ b/include/actions.hpp
@@ -66,6 +66,8 @@ public:
         E_AT_VAR_TO_DOUBLE,
         E_AT_VAR_STRCMP,
         E_AT_VAR_TRIM,
+        E_AT_VAR_URLDECODE,
+        E_AT_VAR_URLENCODE,
         E_AT_VERIFY_AUTH,
         E_AT_SET_DEST,
         E_AT_CLOSE_CON,

--- a/include/urlcoder.hpp
+++ b/include/urlcoder.hpp
@@ -1,0 +1,26 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  Author : Jérôme Poulin - 20 Apr 2021
+ */
+
+#ifndef SIPP_URLCODER_HPP
+#define SIPP_URLCODER_HPP
+
+std::string url_encode(const std::string& str);
+std::string url_decode(std::string str);
+
+
+#endif //SIPP_URLCODER_HPP

--- a/sipp.dtd
+++ b/sipp.dtd
@@ -67,7 +67,7 @@
 <!ELEMENT CallLengthRepartition EMPTY >
 <!ATTLIST CallLengthRepartition value CDATA #REQUIRED >
 
-<!ELEMENT action ( add | assign | assignstr | closecon | divide | ereg | error | exec | gettimeofday | index | insert | jump | log | lookup | multiply | pauserestore | replace | rtp_echo | sample | setdest | strcmp | subtract | test | todouble | trim | verifyauth | warning )+ >
+<!ELEMENT action ( add | assign | assignstr | closecon | divide | ereg | error | exec | gettimeofday | index | insert | jump | log | lookup | multiply | pauserestore | replace | rtp_echo | sample | setdest | strcmp | subtract | test | todouble | trim | urldecode | urlencode | verifyauth | warning )+ >
 
 <!-- BEGIN actions -->
 
@@ -111,6 +111,12 @@
 <!ELEMENT assign EMPTY >
 <!ATTLIST assign assign_to CDATA #REQUIRED >
 <!ATTLIST assign variable CDATA #REQUIRED >
+
+<!ELEMENT urldecode EMPTY >
+<!ATTLIST urldecode variable CDATA #REQUIRED >
+
+<!ELEMENT urlencode EMPTY >
+<!ATTLIST urlencode variable CDATA #REQUIRED >
 
 <!-- END actions -->
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -143,6 +143,10 @@ void CAction::printInfo(char* buf, int len)
         snprintf(buf, len, "Type[%d] - divide varId[%s] %lf", M_action, display_scenario->allocVars->getName(M_varId), M_doubleValue);
     } else if (M_action == E_AT_VAR_TRIM) {
         snprintf(buf, len, "Type[%d] - trim varId[%s]", M_action, display_scenario->allocVars->getName(M_varId));
+    } else if (M_action == E_AT_VAR_URLDECODE) {
+        snprintf(buf, len, "Type[%d] - urldecode varId[%s]", M_action, display_scenario->allocVars->getName(M_varId));
+    } else if (M_action == E_AT_VAR_URLENCODE) {
+        snprintf(buf, len, "Type[%d] - urlencode varId[%s]", M_action, display_scenario->allocVars->getName(M_varId));
     } else if (M_action == E_AT_VAR_TEST) {
         snprintf(buf, len, "Type[%d] - divide varId[%s] varInId[%s] %s %lf", M_action, display_scenario->allocVars->getName(M_varId), display_scenario->allocVars->getName(M_varInId), comparatorToString(M_comp), M_doubleValue);
     } else if (M_action == E_AT_VAR_TO_DOUBLE) {

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -58,6 +58,7 @@
 
 #include "sipp.hpp"
 #include "auth.hpp"
+#include "urlcoder.hpp"
 #include "deadcall.hpp"
 #include "config.h"
 #include "version.h"
@@ -6034,6 +6035,18 @@ call::T_ActionResult call::executeAction(const char* msg, message* curmsg)
             for (int i = l - 1; (i >= 0) && isspace(q[i]); i--) {
                 q[i] = '\0';
             }
+        } else if (currentAction->getActionType() == CAction::E_AT_VAR_URLDECODE) {
+            CCallVariable *var = M_callVariableTable->getVar(currentAction->getVarId());
+            string input = var->getString();
+            string output = url_decode(input);
+            char *char_output = strdup(output.c_str());
+            var->setString(char_output);
+        } else if (currentAction->getActionType() == CAction::E_AT_VAR_URLENCODE) {
+            CCallVariable *var = M_callVariableTable->getVar(currentAction->getVarId());
+            string input = var->getString();
+            string output = url_encode(input);
+            char *char_output = strdup(output.c_str());
+            var->setString(char_output);
         } else if (currentAction->getActionType() == CAction::E_AT_VAR_TO_DOUBLE) {
             double value;
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -1628,6 +1628,12 @@ void scenario::parseAction(CActions *actions)
         } else if(!strcmp(actionElem, "trim")) {
             tmpAction->setVarId(xp_get_var("assign_to", "trim"));
             tmpAction->setActionType(CAction::E_AT_VAR_TRIM);
+        } else if(!strcmp(actionElem, "urldecode")) {
+            tmpAction->setVarId(xp_get_var("variable", "urldecode"));
+            tmpAction->setActionType(CAction::E_AT_VAR_URLDECODE);
+        } else if(!strcmp(actionElem, "urlencode")) {
+            tmpAction->setVarId(xp_get_var("variable", "urlencode"));
+            tmpAction->setActionType(CAction::E_AT_VAR_URLENCODE);
         } else if(!strcmp(actionElem, "exec")) {
             if ((cptr = xp_get_value("command"))) {
                 tmpAction->setActionType(CAction::E_AT_EXECUTE_CMD);

--- a/src/urlcoder.cpp
+++ b/src/urlcoder.cpp
@@ -1,0 +1,88 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  Author : Jérôme Poulin - 20 Apr 2021
+ */
+
+#include <cctype>
+#include <string>
+#include <cstring>
+
+std::string url_encode(const std::string &str) {
+    std::string new_str;
+    unsigned char c;
+    int ic;
+    const char *chars = str.c_str();
+    char bufHex[10];
+    size_t len = strlen(chars);
+
+    for (int i = 0; i < len; i++) {
+        c = chars[i];
+        ic = c;
+        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            new_str += c;
+        } else {
+            sprintf(bufHex, "%X", c);
+            if (ic < 16) {
+                new_str += "%0";
+            } else {
+                new_str += "%";
+            }
+            new_str += bufHex;
+        }
+    }
+    return new_str;
+}
+
+std::string url_decode(std::string str) {
+    std::string ret;
+    char ch;
+    int i, ii;
+    size_t len = str.length();
+
+    for (i = 0; i < len; i++) {
+        if (str[i] != '%') {
+            if (str[i] == '+') {
+                ret += ' ';
+            } else {
+                ret += str[i];
+            }
+        } else {
+            sscanf(str.substr(i + 1, 2).c_str(), "%x", &ii);
+            ch = static_cast<char>(ii);
+            ret += ch;
+            i = i + 2;
+        }
+    }
+    return ret;
+}
+
+#ifdef GTEST
+#include "gtest/gtest.h"
+
+TEST(url_encode, encoded_string_contains_entities_if_needed) {
+    ASSERT_EQ(url_encode("user1@127.0.0.1:5060"), "user1%40127.0.0.1%3A5060");
+    ASSERT_EQ(url_encode("string with spaces"), "string%20with%20spaces");
+    ASSERT_EQ(url_encode("alphanum123"), "alphanum123");
+    ASSERT_EQ(url_encode("ûtf8"), "%C3%BBtf8");
+}
+
+TEST(url_decode, decoded_string_contains_no_entities) {
+    ASSERT_EQ(url_decode("user1%40127%2E0%2e0%2e1%3a5060"), "user1@127.0.0.1:5060");
+    ASSERT_EQ(url_decode("string%20with%20spaces"), "string with spaces");
+    ASSERT_EQ(url_decode("%C3%bbtf8"), "ûtf8");
+}
+
+#endif // GTEST


### PR DESCRIPTION
I really need this to decode the URI encoded Call-ID in the Replaces: header of a 3PCC scenario to send it via `<sendCmd>`.