### PR TITLE
Fix formatting for urlencode/decode documentation.

### DIFF
--- a/docs/scenarios/actions.rst
+++ b/docs/scenarios/actions.rst
@@ -488,15 +488,15 @@ urlencode / urldecode
 The urlencode and urldecode actions will replace the content of the
 variable specified in variable with the coded version. For example::
 
-Content of variable_to_be_encoded is "this: is a string".
+For example, if the content of variable_to_be_encoded is
+"this: is a string", then content of variable_to_be_encoded will then
+become "this%3A%20is%20a%20string"::
 
     <nop>
       <action>
         <urlencode variable="variable_to_be_encoded" />
       </action>
     </nop>
-
-Content of variable_to_be_encoded now is "this%3A%20is%20a%20string".
 
 
 


### PR DESCRIPTION
After amending my commit to change the variable="" I broke the formatting for the code-block by misplacing `::`.

![2021-05-03 13_54_24-Actions — SIPp 3 6 documentation — Mozilla Firefox](https://user-images.githubusercontent.com/1229687/116915119-9cd07880-ac19-11eb-85a3-3ac825b2fb81.png)
