### PR TITLE
fix compile fail on centos-7.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ CHECK_STRUCT_HAS_MEMBER("struct udphdr" uh_sport "sys/types.h;netinet/udp.h"  HA
 CHECK_SYMBOL_EXISTS(le16toh "endian.h" HAVE_DECL_LE16TOH)
 CHECK_SYMBOL_EXISTS(le16toh "sys/endian.h" HAVE_DECL_LE16TOH_BSD)
 
+set(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX_FLAGS} -std=c++11)
 CHECK_CXX_SOURCE_COMPILES("
 #include <string>
 int main() { auto s = std::string(\"x\"); s.c_str(); return 0; }


### PR DESCRIPTION
On Centos-7.9 with devtool-set-7 and cmake-3.6.2, compile
fail due to error:

  CMake Error at CMakeLists.txt:60 (message):
    Your C++ compiler is too old (does not support the 'auto' keyword or
    range loops)

But both of these features are supported by devtool-set-7.

The root cause is the missing of cxx standard for macro
CHECK_CXX_SOURCE_COMPILES.

Fix this issue by specify std=cxx11 in variable CMAKE_REQUIRED_FLAGS.

Signed-off-by: zhang junwei <vitaly1979@hotmail.com>