### PR TITLE
Hardcode timezone to GMT

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -3882,8 +3882,8 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
 
             t = time(NULL);
             tm = gmtime(&t);
-
-            strftime(buf, 256, "%a, %d %b %Y %T %Z", tm);
+            /* changed %Z to hardcoded GMT since in some OS like FreeBSD it could return UTC instead, see issue #535 */
+            strftime(buf, 256, "%a, %d %b %Y %T GMT", tm);
             dest += snprintf(dest, left, "%s", buf);
             break;
         case E_Message_Users:


### PR DESCRIPTION
In some OS like FreeBSD the %Z could return UTC instead of GMT, which causes discrepancy for macro [date].
Lets hardcode it to GMT here.
#535 