### PR TITLE
Re-enable regression tests that depend on RTP_STREAM

### DIFF
--- a/regress/github-#0192/run
+++ b/regress/github-#0192/run
@@ -3,10 +3,6 @@
 # Author: Walter Doekes, OSSO B.V., 2016
 . "`dirname "$0"`/../functions"; init
 
-if ! sippversion | grep -q RTPSTREAM; then
-    skip "requires RTPSTREAM"
-fi
-
 uas_media_port=5071
 
 udplisten $uas_media_port >udplisten.log &

--- a/regress/github-#0196/run
+++ b/regress/github-#0196/run
@@ -8,10 +8,6 @@
 #
 . "`dirname "$0"`/../functions"; init
 
-if ! sippversion | grep -q RTPSTREAM; then
-    skip "requires RTPSTREAM"
-fi
-
 uac_media_port=5072  # client port
 uas_media_port=5071  # server port
 

--- a/regress/github-#0259/run
+++ b/regress/github-#0259/run
@@ -7,10 +7,6 @@
 #
 . "`dirname "$0"`/../functions"; init
 
-if ! sippversion | grep -q RTPSTREAM; then
-    skip "requires RTPSTREAM"
-fi
-
 sippbg -sf uas.xml -p 5070 -rtp_echo
 sippfg -m 1 -sf uac.xml 127.0.0.1:5070 \
     -timeout 10 -timeout_error >/dev/null 2>&1


### PR DESCRIPTION
RTP_STREAM is now unconditional, and no longer appears in the version.

Amends commit 70b93e4ca5e3a36c71c4f400751520abbe965718.