### PR TITLE
FileContents: Strip trailing \r

### DIFF
--- a/src/infile.cpp
+++ b/src/infile.cpp
@@ -49,6 +49,9 @@ FileContents::FileContents(const char *fileName)
 
     std::string lineStr;
     std::getline(*inFile, lineStr);
+    if (!lineStr.empty() && *lineStr.rbegin() == '\r') {
+        lineStr.pop_back();
+    }
     const char* line = lineStr.c_str();
 
     if (NULL != strstr(line, "RANDOM")) {


### PR DESCRIPTION
If the file has CRLF line endings, `\r` is not stripped
by `std::getline`, and it is read as part of the string.