### PR TITLE
Fix cygwin/msys2 compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,10 @@ if(SIPP_MAX_MSG_SIZE)
   add_definitions("-DSIPP_MAX_MSG_SIZE=${SIPP_MAX_MSG_SIZE}")
 endif(SIPP_MAX_MSG_SIZE)
 
+if(CYGWIN)
+  add_definitions("-D_GNU_SOURCE")
+endif(CYGWIN)
+
 if(USE_GSL AND GSL_LIBRARY)
   target_link_libraries(sipp gsl gslcblas)
   target_link_libraries(sipp_unittest gsl gslcblas)

--- a/src/sip_parser.cpp
+++ b/src/sip_parser.cpp
@@ -37,10 +37,6 @@
  *           Walter Doekes
  */
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE /* needed for strcasestr on cygwin */
-#endif
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -35,10 +35,6 @@
  *           Michael Hirschbichler
  */
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE /* needed for strcasestr on cygwin */
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
`u_char` is used in pcap, and it is only defined if _GNU_SOURCE is set.
