### PR TITLE
Get rid of alloca usage

### DIFF
--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -60,10 +60,6 @@
 #include <stdarg.h>
 #endif
 
-#if defined(__HPUX) || defined(__SUNOS)
-#include <alloca.h>
-#endif
-
 /* Sipp includes */
 
 #include "xp_parser.h"


### PR DESCRIPTION
Replace with std::vector.

alloca requires #include <alloca.h> on MSYS2, but there is no good
reason to use it in C++ code anyway.