### PR TITLE
CMakeLists.txt fix for installation on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS False)
 # specify the C++ standard on older CMake (<3.8)
-set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -pedantic -Wno-error=format-truncation -Wno-error=deprecated-declarations")
 
 if(EXISTS ./gmock/CMakeLists.txt)


### PR DESCRIPTION
The change referenced to issue #559
Fix the installation on FreeBSD by usage of CMAKE_CXX_FLAGS instead of CMAKE_REQUIRED_FLAGS