### PR TITLE
RTPCHECK stability fixes [bug #544]

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -479,6 +479,12 @@ int call::extract_srtp_remote_info(const char * msg, SrtpAudioInfoParams &pA, Sr
         }
 
         /* --------------------------------------------------------------
+         * Determine SDP m-line structure
+         * -------------------------------------------------------------- */
+        amsection_limit = msgstr.find("\nm=audio", 0, msgstr.size());
+        vmsection_limit = msgstr.find("\nm=video", 0, msgstr.size());
+
+        /* --------------------------------------------------------------
          * Try to find an AUDIO MLINE
          * -------------------------------------------------------------- */
         pos1 = msgstr.find(SDP_AUDIOPORT_PREFIX, 0, 8);
@@ -547,8 +553,6 @@ int call::extract_srtp_remote_info(const char * msg, SrtpAudioInfoParams &pA, Sr
         }
 
         cur_pos = pos2;
-        amsection_limit = msgstr.find("\nm=audio", cur_pos, 8);
-        vmsection_limit = msgstr.find("\nm=video", cur_pos, 8);
 
         if (audioExists &&
             (((amsection_limit != std::string::npos) && (cur_pos != std::string::npos) && (cur_pos < amsection_limit)) ||
@@ -673,8 +677,6 @@ int call::extract_srtp_remote_info(const char * msg, SrtpAudioInfoParams &pA, Sr
         }
 
         cur_pos = pos2;
-        vmsection_limit = msgstr.find("\nm=video", cur_pos, 8);
-        amsection_limit = msgstr.find("\nm=audio", cur_pos, 8);
 
         if (videoExists &&
             (((vmsection_limit != std::string::npos) && (cur_pos != std::string::npos) && (cur_pos < vmsection_limit)) ||

--- a/src/rtpstream.cpp
+++ b/src/rtpstream.cpp
@@ -2614,7 +2614,6 @@ void rtpstream_audioecho_thread(void* param)
     std::vector<unsigned char> payload_data;
     std::vector<unsigned char> audio_packet_in;
     std::vector<unsigned char> audio_packet_out;
-    unsigned short audio_seq = 0;
     unsigned short seq_num = 0;
     unsigned short host_flags = 0;
     unsigned short host_seqnum = 0;
@@ -2711,7 +2710,7 @@ void rtpstream_audioecho_thread(void* param)
                     payload_data.clear();
 
                     // DECRYPT
-                    rc = g_rxUASAudio.processIncomingPacket(audio_seq, audio_packet_in, rtp_header, payload_data);
+                    rc = g_rxUASAudio.processIncomingPacket(seq_num, audio_packet_in, rtp_header, payload_data);
                     pthread_mutex_lock(&debugremutexaudio);
                     if (debugrefileaudio != NULL)
                     {
@@ -2753,7 +2752,7 @@ void rtpstream_audioecho_thread(void* param)
                     memcpy(payload_data.data(), msg.get() + sizeof(rtp_header_t), g_txUASAudio.getSrtpPayloadSize());
 
                     // ENCRYPT
-                    rc = g_txUASAudio.processOutgoingPacket(audio_seq, rtp_header, payload_data, audio_packet_out);
+                    rc = g_txUASAudio.processOutgoingPacket(seq_num, rtp_header, payload_data, audio_packet_out);
                     pthread_mutex_lock(&debugremutexaudio);
                     if (debugrefileaudio != NULL)
                     {
@@ -2782,7 +2781,6 @@ void rtpstream_audioecho_thread(void* param)
 
                 rtp_pckts++;
                 rtp_bytes += ns;
-                audio_seq++;
             }
             else if ((nr < 0) &&
                      (errno == EAGAIN)) {
@@ -2875,7 +2873,6 @@ void rtpstream_videoecho_thread(void* param)
     std::vector<unsigned char> payload_data;
     std::vector<unsigned char> video_packet_in;
     std::vector<unsigned char> video_packet_out;
-    unsigned short video_seq = 0;
     unsigned short seq_num = 0;
     unsigned short host_flags = 0;
     unsigned short host_seqnum = 0;
@@ -2971,7 +2968,7 @@ void rtpstream_videoecho_thread(void* param)
                     rtp_header.clear();
                     payload_data.clear();
                     // DECRYPT
-                    rc = g_rxUASVideo.processIncomingPacket(video_seq, video_packet_in, rtp_header, payload_data);
+                    rc = g_rxUASVideo.processIncomingPacket(seq_num, video_packet_in, rtp_header, payload_data);
                     pthread_mutex_lock(&debugremutexvideo);
                     if (debugrefilevideo != NULL)
                     {
@@ -3013,7 +3010,7 @@ void rtpstream_videoecho_thread(void* param)
                     memcpy(payload_data.data(), msg.get() + sizeof(rtp_header_t), g_txUASVideo.getSrtpPayloadSize());
 
                     // ENCRYPT
-                    rc = g_txUASVideo.processOutgoingPacket(video_seq, rtp_header, payload_data, video_packet_out);
+                    rc = g_txUASVideo.processOutgoingPacket(seq_num, rtp_header, payload_data, video_packet_out);
                     pthread_mutex_lock(&debugremutexvideo);
                     if (debugrefilevideo != NULL)
                     {
@@ -3042,7 +3039,6 @@ void rtpstream_videoecho_thread(void* param)
 
                 rtp2_pckts++;
                 rtp2_bytes += ns;
-                video_seq++;
             }
             else if ((nr < 0) &&
                      (errno == EAGAIN)) {


### PR DESCRIPTION
- SRTP echo sequence number (resolves timing-dependent SRTP echo failures when using AUDIO and/or VIDEO media)
- SDP m-line delimiter parsing (resolves test scenarios SRTP echo failures when using BOTH AUDIO+VIDEO media)