### PR TITLE
Few additions to the code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(USE_SSL "Build with SIPS support" OFF)
 option(USE_SCTP "Build with SCTP support" OFF)
 option(USE_PCAP "Build with PCAP playback support" OFF)
 option(USE_GSL "Build with improved statistical support" ON)
+option(USE_LOCAL_IP_HINTS "Build with local ip hints priority" OFF)
 
 file(GLOB all_SRCS
   "${PROJECT_SOURCE_DIR}/src/*.cpp"
@@ -109,6 +110,10 @@ endif()
 if(USE_PCAP)
   add_definitions("-DPCAPPLAY")
 endif(USE_PCAP)
+
+if(USE_LOCAL_IP_HINTS)
+  add_definitions("-DUSE_LOCAL_IP_HINTS")
+endif(USE_LOCAL_IP_HINTS)
 
 if(USE_GSL)
   find_library(GSL_LIBRARY gsl)

--- a/src/prepare_pcap.c
+++ b/src/prepare_pcap.c
@@ -361,7 +361,7 @@ struct nooppacket {
     struct rtpnoop noop;
 };
 
-static u_long dtmf_ssrcid = 0x01020304; /* bug, should be random/unique */
+static u_long dtmf_ssrcid = 0;
 
 static void fill_default_udphdr(struct udphdr* udp, u_long pktlen)
 {
@@ -544,6 +544,12 @@ int prepare_dtmf(const char* digits, pcap_pkts* pkts, uint16_t start_seq_no)
 
     unsigned long ts_offset = 0; /* packet timestamp */
     unsigned timestamp_start = 24000; /* RTP timestamp, should be random */
+
+    /* generate random ssrc */
+    if (dtmf_ssrcid == 0) {
+        srand(time(NULL));
+        dtmf_ssrcid = rand();
+    }
 
     /* If we see the DTMF as part of the entire audio stream, we'd need
      * to reuse the SSRC, but it's legal to start a new stream (new

--- a/src/rtpstream.cpp
+++ b/src/rtpstream.cpp
@@ -121,7 +121,7 @@ int           num_ready_threads = 0;
 int           busy_threads_max = 0;
 int           ready_threads_max = 0;
 
-unsigned int  global_ssrc_id = 0xCA110000;
+unsigned int  global_ssrc_id = 0;
 
 FILE*         debugafile = NULL;
 FILE*         debugvfile = NULL;
@@ -1595,6 +1595,12 @@ int rtpstream_new_call(rtpstream_callinfo_t* callinfo)
     taskinfo->audio_srtp_echo_active = 0;
     taskinfo->video_srtp_echo_active = 0;
 #endif // USE_TLS
+
+    /* generate random ssrc */
+    if (global_ssrc_id == 0) {
+        srand(time(NULL));
+        global_ssrc_id = rand();
+    }
 
     /* rtp stream members */
     taskinfo->audio_ssrc_id = global_ssrc_id++;

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -1133,25 +1133,25 @@ void sipp_exit(int rc, int rtp_errors, int echo_errors)
         // Exit is not a normal exit. Just use the passed exit code.
         exit(rc);
     } else {
+        // log rtp stream errors
+        if ((rtp_errors > 0) || (echo_errors > 0)) {
+            WARNING("GOT rtp errors = %d or echo errors = %d", rtp_errors, echo_errors);
+        }
+
         // Normal exit: we need to determine if the calls were all
         // successful or not. In order to compute the return code, get
         // the counter of failed calls. If there is 0 failed calls,
         // then everything is OK!
-        if ((rtp_errors > 0) || (echo_errors > 0))
-        {
-            exit(EXIT_RTPCHECK_FAILED);
-        }
-        else
-        {
-           if (counter_value_failed == 0) {
-                if ((timeout_exit) && (counter_value_success < 1)) {
-                    exit (EXIT_TEST_RES_INTERNAL);
-                } else {
-                    exit(EXIT_TEST_OK);
-                }
+        if (counter_value_failed == 0) {
+            if ((timeout_exit) && (counter_value_success < 1)) {
+                exit (EXIT_TEST_RES_INTERNAL);
             } else {
-                exit(EXIT_TEST_FAILED);
+                exit(EXIT_TEST_OK);
             }
+        } else if ((rtp_errors > 0) || (echo_errors > 0)) {
+            exit(EXIT_RTPCHECK_FAILED);
+        } else {
+            exit(EXIT_TEST_FAILED);
         }
     }
 }

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2332,10 +2332,34 @@ int open_connections()
         /* Resolving the remote IP */
         {
             fprintf(stderr, "Resolving remote host '%s'... ", remote_host);
+            struct addrinfo   hints;
+
+            memset((char*)&hints, 0, sizeof(hints));
+            hints.ai_flags  = AI_PASSIVE;
+            hints.ai_family = AF_UNSPEC;
+
+#ifdef USE_LOCAL_IP_HINTS
+            struct addrinfo * local_addr;
+            int ret;
+            if (strlen(local_ip)) {
+                if ((ret = getaddrinfo(local_ip, NULL, &hints, &local_addr)) != 0) {
+                    ERROR("Can't get local IP address in getaddrinfo, "
+                            "local_ip='%s', ret=%d", local_ip, ret);
+                }
+
+                /* Use local address hints when getting the remote */
+                if (local_addr->ai_addr->sa_family == AF_INET6) {
+                    local_ip_is_ipv6 = true;
+                    hints.ai_family = AF_INET6;
+                } else {
+                    hints.ai_family = AF_INET;
+                }
+            }
+#endif
 
             /* FIXME: add DNS SRV support using liburli? */
             if (gai_getsockaddr(&remote_sockaddr, remote_host, remote_port,
-                                AI_PASSIVE, AF_UNSPEC) != 0) {
+                                hints.ai_flags, hints.ai_family) != 0) {
                 ERROR("Unknown remote host '%s'.\n"
                       "Use 'sipp -h' for details", remote_host);
             }

--- a/src/sslsocket.cpp
+++ b/src/sslsocket.cpp
@@ -126,11 +126,39 @@ const char *SSL_error_string(int ssl_error, int orig_ret)
 
 SSL* SSL_new_client()
 {
+
+    if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx_client,
+                                     tls_cert_name,
+                                     SSL_FILETYPE_PEM) != 1) {
+        printf("SSL_new_client: SSL_CTX_use_certificate_file failed");
+    }
+
+    if (SSL_CTX_use_PrivateKey_file(sip_trp_ssl_ctx_client,
+                                     tls_key_name,
+                                     SSL_FILETYPE_PEM) != 1) {
+        printf("SSL_new_client: SSL_CTX_use_PrivateKey_file failed");
+    }
+
     return SSL_new(sip_trp_ssl_ctx_client);
 }
 
 SSL* SSL_new_server()
 {
+
+    if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx,
+                                     tls_cert_name,
+                                     SSL_FILETYPE_PEM) != 1) {
+        ERROR("SSL_new_server: SSL_CTX_use_certificate_file failed");
+        return NULL;
+    }
+
+    if (SSL_CTX_use_PrivateKey_file(sip_trp_ssl_ctx,
+                                     tls_key_name,
+                                     SSL_FILETYPE_PEM) != 1) {
+        ERROR("SSL_new_server: SSL_CTX_use_PrivateKey_file failed");
+        return NULL;
+    }
+
     return SSL_new(sip_trp_ssl_ctx);
 }
 
@@ -332,33 +360,6 @@ enum tls_init_status TLS_init_context(void)
                                   passwd_call_back_routine);
     SSL_CTX_set_default_passwd_cb(sip_trp_ssl_ctx_client,
                                   passwd_call_back_routine);
-
-    if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx,
-                                     tls_cert_name,
-                                     SSL_FILETYPE_PEM) != 1) {
-        ERROR("TLS_init_context: SSL_CTX_use_certificate_file failed");
-        return TLS_INIT_ERROR;
-    }
-
-    if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx_client,
-                                     tls_cert_name,
-                                     SSL_FILETYPE_PEM) != 1) {
-        ERROR("TLS_init_context: SSL_CTX_use_certificate_file (client) failed");
-        return TLS_INIT_ERROR;
-    }
-    if (SSL_CTX_use_PrivateKey_file(sip_trp_ssl_ctx,
-                                     tls_key_name,
-                                     SSL_FILETYPE_PEM) != 1) {
-        ERROR("TLS_init_context: SSL_CTX_use_PrivateKey_file failed");
-        return TLS_INIT_ERROR;
-    }
-
-    if (SSL_CTX_use_PrivateKey_file(sip_trp_ssl_ctx_client,
-                                    tls_key_name,
-                                    SSL_FILETYPE_PEM) != 1) {
-        ERROR("TLS_init_context: SSL_CTX_use_PrivateKey_file (client) failed");
-        return TLS_INIT_ERROR;
-    }
 
     return TLS_INIT_NORMAL;
 }


### PR DESCRIPTION
Hello, we are using SIPp with the following features and I wonder if they are of interest for the upstream community:

1. Add define to use local ip hints

When USE_LOCAL_IP_HINTS is defined, prioritize local interface hints and
use them when deciding the remote address.

Useful when remote is a FQDN which can resolve to both IPv4 nd IPv6.

2. Generate random SSRC

3. Return ok if xml scenario finished ok. Log rtp or echo errors

4. Make TLS client cert/key file optional

Thank you,
Stefan