### PR TITLE
Fix for local_port keyword using TCP or TLS

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2566,6 +2566,11 @@ int open_connections()
         }
         sipp_customize_socket(tcp_multiplex);
 
+        /* This fixes local_port keyword value when transport are TCP|TLS and it's defined by user with "-p" */
+        if (sipp_bind_socket(tcp_multiplex, &local_sockaddr, NULL)) {
+            ERROR_NO("Unable to bind TCP socket");
+        }
+
         if (tcp_multiplex->connect(&remote_sockaddr)) {
             if (reset_number > 0) {
                 WARNING("Failed to reconnect");


### PR DESCRIPTION
This is an old issue related in older versions and still without a definitive fix.
Thanks to Patrick Wakano who proposed it at Sipp-devel mailing list at 2013. [https://sourceforge.net/p/sipp/mailman/message/31219335/]