### PR TITLE
[UAS] Copy Record-Route from INVITE to 200OK to comply with rfc3261

### DIFF
--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -2204,6 +2204,7 @@ const char * default_scenario [] = {
     "\n"
     "      SIP/2.0 200 OK\n"
     "      [last_Via:]\n"
+    "      [last_Record-Route:]\n"
     "      [last_From:]\n"
     "      [last_To:];tag=[pid]SIPpTag01[call_number]\n"
     "      [last_Call-ID:]\n"


### PR DESCRIPTION
When a UAS responds to a request with a response that establishes a
   dialog (such as a 2xx to INVITE), the UAS MUST copy all Record-Route
   header field values from the request into the response (including the
   URIs, URI parameters, and any Record-Route header field parameters,
   whether they are known or unknown to the UAS) and MUST maintain the
   order of those values.