### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/src/time.cpp
+++ b/src/time.cpp
@@ -39,7 +39,7 @@
 #include <time.h>
 #include <sys/time.h>
 #include <unistd.h>
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
@@ -57,7 +57,7 @@ unsigned long long getmicroseconds()
     unsigned long long microseconds;
     static unsigned long long start_time = 0;
 
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
     // OS X does not have clock_gettime, use clock_get_time
     clock_serv_t cclock;
     mach_timespec_t mts;


### PR DESCRIPTION
As said on line 60, this check is only intended for OSX.
```
// OS X does not have clock_gettime, use clock_get_time
```

Hurd also uses Mach, but does not have the same shortcomings as OSX in this area.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```