### PR TITLE
Add 'transport' to the Contact header for UAC scenarios

### DIFF
--- a/sipp_scenarios/pfca_uac.xml
+++ b/sipp_scenarios/pfca_uac.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -69,7 +69,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -114,7 +114,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern.xml
+++ b/sipp_scenarios/pfca_uac_apattern.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -70,7 +70,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -172,7 +172,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_aescm128sha132.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_aescm128sha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_aescm128sha132_ue.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_aescm128sha132_ue.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_aescm128sha180.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_aescm128sha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_aescm128sha180_ue.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_aescm128sha180_ue.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_g711a.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_g711a.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_g711u.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_g711u.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_g722.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_g722.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_g729.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_g729.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_nullsha132.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_nullsha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_nullsha180.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_nullsha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -194,7 +194,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_aescm128sha132.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_aescm128sha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -194,7 +194,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_aescm128sha180.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_aescm128sha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -194,7 +194,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_nullsha132.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_nullsha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -194,7 +194,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_nullsha180.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_nullsha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -194,7 +194,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_reuse.xml
+++ b/sipp_scenarios/pfca_uac_apattern_crypto_simple_renegotiation_reuse.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -120,7 +120,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -194,7 +194,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_g711a.xml
+++ b/sipp_scenarios/pfca_uac_apattern_g711a.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -70,7 +70,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -172,7 +172,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_g711u.xml
+++ b/sipp_scenarios/pfca_uac_apattern_g711u.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -70,7 +70,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -172,7 +172,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_g722.xml
+++ b/sipp_scenarios/pfca_uac_apattern_g722.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -70,7 +70,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -172,7 +172,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_apattern_g729.xml
+++ b/sipp_scenarios/pfca_uac_apattern_g729.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -70,7 +70,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -172,7 +172,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_avpattern.xml
+++ b/sipp_scenarios/pfca_uac_avpattern.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -84,7 +84,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -194,7 +194,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_aescm128sha132.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_aescm128sha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_aescm128sha132_ue.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_aescm128sha132_ue.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_aescm128sha180.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_aescm128sha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_aescm128sha180_ue.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_aescm128sha180_ue.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_nullsha132.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_nullsha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_nullsha180.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_nullsha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -228,7 +228,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_aescm128sha132.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_aescm128sha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -228,7 +228,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_aescm128sha180.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_aescm128sha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -228,7 +228,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_nullsha132.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_nullsha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -228,7 +228,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_nullsha180.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_nullsha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -228,7 +228,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_reuse.xml
+++ b/sipp_scenarios/pfca_uac_bpattern_crypto_simple_renegotiation_reuse.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -88,7 +88,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -137,7 +137,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -228,7 +228,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern.xml
+++ b/sipp_scenarios/pfca_uac_vpattern.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -72,7 +72,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -174,7 +174,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_aescm128sha132.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_aescm128sha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_aescm128sha132_ue.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_aescm128sha132_ue.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_aescm128sha180.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_aescm128sha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_aescm128sha180_ue.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_aescm128sha180_ue.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_nullsha132.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_nullsha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_nullsha180.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_nullsha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -198,7 +198,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_aescm128sha132.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_aescm128sha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -198,7 +198,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_aescm128sha180.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_aescm128sha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -198,7 +198,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_nullsha132.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_nullsha132.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -198,7 +198,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_nullsha180.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_nullsha180.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -198,7 +198,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)

--- a/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_reuse.xml
+++ b/sipp_scenarios/pfca_uac_vpattern_crypto_simple_renegotiation_reuse.xml
@@ -14,7 +14,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: 10 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -74,7 +74,7 @@
       Call-ID: [call_id]
       CSeq: 11 PRACK
       RAck: [$2][$1]
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       Content-Length: 0
@@ -122,7 +122,7 @@
       To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 12 INVITE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)
@@ -198,7 +198,7 @@
       To: <sip:[service]@[remote_ip]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 13 BYE
-      Contact: <sip:16001@[local_ip]:[local_port]>
+      Contact: <sip:16001@[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Subject: Conference
       User-Agent: VIRTUAL Mitel-UC-Endpoint (Mitel UC360 Collaboration Point/2.1.0.99;  08:00:0F:74:80:E1)


### PR DESCRIPTION
Adding missing `;transport=[transport]` into Contact header for all UAC scenarion.
Not sure which all files I have to change, but my idea was to use also TCP transport with SIPp UAC scenario.
The default one, generated with `sipp -sd uac` is not working for me, because of this.