### PR TITLE
Fix to [next_url] when a display name is present in the contact

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -4346,13 +4346,14 @@ void call::formatNextReqUrl(const char* contact)
     while (*contact != '\0' && (*contact == ' ' || *contact == '\t')) {
         ++contact;
     }
-    if (*contact == '<') {
-        contact += 1;
-        const char* end = strchr(contact, '>');
-        if (end) {
-            next_req_url[0] = '\0';
-            strncat(next_req_url, contact,
-                    min(MAX_HEADER_LEN - 1, (int)(end - contact))); /* fits MAX_HEADER_LEN */
+	const char* start = strchr(contact, '<');
+    const char* end = strchr(contact, '>');
+    if ((start && end)  && (start < end)) {
+        contact = start;
+        contact++;
+        next_req_url[0] = '\0';
+        strncat(next_req_url, contact,
+                min(MAX_HEADER_LEN - 1, (int)(end - contact))); /* fits MAX_HEADER_LEN */
         }
     } else {
         next_req_url[0] = '\0';

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -4346,7 +4346,7 @@ void call::formatNextReqUrl(const char* contact)
     while (*contact != '\0' && (*contact == ' ' || *contact == '\t')) {
         ++contact;
     }
-	const char* start = strchr(contact, '<');
+    const char* start = strchr(contact, '<');
     const char* end = strchr(contact, '>');
     if ((start && end)  && (start < end)) {
         contact = start;

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -4354,7 +4354,6 @@ void call::formatNextReqUrl(const char* contact)
         next_req_url[0] = '\0';
         strncat(next_req_url, contact,
                 min(MAX_HEADER_LEN - 1, (int)(end - contact))); /* fits MAX_HEADER_LEN */
-        }
     } else {
         next_req_url[0] = '\0';
         strncat(next_req_url, contact, MAX_HEADER_LEN - 1);


### PR DESCRIPTION
based on an earlier PR which seems to have regressed 
https://github.com/SIPp/sipp/pull/367

someone else opened an issue earlier:
https://github.com/SIPp/sipp/issues/586

I'm not familiar with this project tests so I skipped changing the test files. I have verified the fix with a local scenario.

Regards Rene

