### PR TITLE
[aka-auth] handle binary passwords

### DIFF
--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -388,7 +388,7 @@ int createAuthHeaderMD5(
     }
 
     createAuthResponseMD5(
-        user, password, strlen(password), method, sipuri, authtype,
+        user, password, password_len, method, sipuri, authtype,
         msgbody, realm, nonce, cnonce, nc, &resp_hex[0]);
 
     written += snprintf(


### PR DESCRIPTION
createAuthHeaderMD5 called from createAuthHeaderAKAv1MD5 may receive a password (RES) with 0s in it. using strlen() on this buffer results in wrong response calculated 