### PR TITLE
print OpenSSL error reason when certificate load fails

### DIFF
--- a/src/sslsocket.cpp
+++ b/src/sslsocket.cpp
@@ -336,14 +336,14 @@ enum tls_init_status TLS_init_context(void)
     if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx,
                                      tls_cert_name,
                                      SSL_FILETYPE_PEM) != 1) {
-        ERROR("TLS_init_context: SSL_CTX_use_certificate_file failed");
+        ERROR("TLS_init_context: SSL_CTX_use_certificate_file failed: %s",ERR_error_string( ERR_get_error(), NULL ));
         return TLS_INIT_ERROR;
     }
 
     if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx_client,
                                      tls_cert_name,
                                      SSL_FILETYPE_PEM) != 1) {
-        ERROR("TLS_init_context: SSL_CTX_use_certificate_file (client) failed");
+        ERROR("TLS_init_context: SSL_CTX_use_certificate_file (client) failed: %s",ERR_error_string( ERR_get_error(), NULL ));
         return TLS_INIT_ERROR;
     }
     if (SSL_CTX_use_PrivateKey_file(sip_trp_ssl_ctx,

--- a/src/sslsocket.cpp
+++ b/src/sslsocket.cpp
@@ -336,14 +336,18 @@ enum tls_init_status TLS_init_context(void)
     if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx,
                                      tls_cert_name,
                                      SSL_FILETYPE_PEM) != 1) {
-        ERROR("TLS_init_context: SSL_CTX_use_certificate_file failed: %s",ERR_error_string( ERR_get_error(), NULL ));
+        char errbuf[256] = { '\0' };
+        ERR_error_string_n( ERR_get_error(), errbuf, sizeof(errbuf) );
+        ERROR("TLS_init_context: SSL_CTX_use_certificate_file failed: %s", errbuf);
         return TLS_INIT_ERROR;
     }
 
     if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx_client,
                                      tls_cert_name,
                                      SSL_FILETYPE_PEM) != 1) {
-        ERROR("TLS_init_context: SSL_CTX_use_certificate_file (client) failed: %s",ERR_error_string( ERR_get_error(), NULL ));
+        char errbuf[256] = { '\0' };
+        ERR_error_string_n( ERR_get_error(), errbuf, sizeof(errbuf) );
+        ERROR("TLS_init_context: SSL_CTX_use_certificate_file (client) failed: %s", errbuf);
         return TLS_INIT_ERROR;
     }
     if (SSL_CTX_use_PrivateKey_file(sip_trp_ssl_ctx,

--- a/src/sslsocket.cpp
+++ b/src/sslsocket.cpp
@@ -336,8 +336,8 @@ enum tls_init_status TLS_init_context(void)
     if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx,
                                      tls_cert_name,
                                      SSL_FILETYPE_PEM) != 1) {
-        char errbuf[256] = { '\0' };
-        ERR_error_string_n( ERR_get_error(), errbuf, sizeof(errbuf) );
+        char errbuf[256] = {'\0'};
+        ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         ERROR("TLS_init_context: SSL_CTX_use_certificate_file failed: %s", errbuf);
         return TLS_INIT_ERROR;
     }
@@ -345,8 +345,8 @@ enum tls_init_status TLS_init_context(void)
     if (SSL_CTX_use_certificate_file(sip_trp_ssl_ctx_client,
                                      tls_cert_name,
                                      SSL_FILETYPE_PEM) != 1) {
-        char errbuf[256] = { '\0' };
-        ERR_error_string_n( ERR_get_error(), errbuf, sizeof(errbuf) );
+        char errbuf[256] = {'\0'};
+        ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         ERROR("TLS_init_context: SSL_CTX_use_certificate_file (client) failed: %s", errbuf);
         return TLS_INIT_ERROR;
     }


### PR DESCRIPTION
When OpenSSL security level is not changed, this error may help to identify error reasons like short key size etc