### PR TITLE
Add define to use local ip hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(USE_SSL "Build with SIPS support" OFF)
 option(USE_SCTP "Build with SCTP support" OFF)
 option(USE_PCAP "Build with PCAP playback support" OFF)
 option(USE_GSL "Build with improved statistical support" ON)
+option(USE_LOCAL_IP_HINTS "Build with local ip hints priority" OFF)
 
 file(GLOB all_SRCS
   "${PROJECT_SOURCE_DIR}/src/*.cpp"
@@ -119,6 +120,10 @@ endif()
 if(USE_PCAP)
   add_definitions("-DPCAPPLAY")
 endif(USE_PCAP)
+
+if(USE_LOCAL_IP_HINTS)
+  add_definitions("-DUSE_LOCAL_IP_HINTS")
+endif(USE_LOCAL_IP_HINTS)
 
 if(USE_GSL)
   find_library(GSL_LIBRARY gsl)

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2336,10 +2336,34 @@ int open_connections()
         /* Resolving the remote IP */
         {
             fprintf(stderr, "Resolving remote host '%s'... ", remote_host);
+            struct addrinfo   hints;
+
+            memset((char*)&hints, 0, sizeof(hints));
+            hints.ai_flags  = AI_PASSIVE;
+            hints.ai_family = AF_UNSPEC;
+
+#ifdef USE_LOCAL_IP_HINTS
+            struct addrinfo * local_addr;
+            int ret;
+            if (strlen(local_ip)) {
+                if ((ret = getaddrinfo(local_ip, NULL, &hints, &local_addr)) != 0) {
+                    ERROR("Can't get local IP address in getaddrinfo, "
+                            "local_ip='%s', ret=%d", local_ip, ret);
+                }
+
+                /* Use local address hints when getting the remote */
+                if (local_addr->ai_addr->sa_family == AF_INET6) {
+                    local_ip_is_ipv6 = true;
+                    hints.ai_family = AF_INET6;
+                } else {
+                    hints.ai_family = AF_INET;
+                }
+            }
+#endif
 
             /* FIXME: add DNS SRV support using liburli? */
             if (gai_getsockaddr(&remote_sockaddr, remote_host, remote_port,
-                                AI_PASSIVE, AF_UNSPEC) != 0) {
+                                hints.ai_flags, hints.ai_family) != 0) {
                 ERROR("Unknown remote host '%s'.\n"
                       "Use 'sipp -h' for details", remote_host);
             }


### PR DESCRIPTION
When USE_LOCAL_IP_HINTS is defined, prioritize local interface hints and use them when deciding the remote address.

Useful when remote is a FQDN which can resolve to both IPv4 nd IPv6.

related to #569