### PR TITLE
Prevent abnormal exit when connection failed

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -1629,7 +1629,7 @@ char * call::send_scene(int index, int *send_status, int *len)
 
     /* Socket port must be known before string substitution */
     if (!connect_socket_if_needed()) {
-        *send_status = -2;
+        *send_status = -3;
         return NULL;
     }
 
@@ -1945,10 +1945,16 @@ bool call::executeMessage(message *curmsg)
         }
 
         msg_snd = send_scene(msg_index, &send_status, &msgLen);
-        if (!msg_snd) {
+        if (send_status == -3) {
             /* This will hit connect_if_needed, and if it fails, the
                entire call is deleted... */
-            ERROR("Call failed, cannot continue safely...");
+            if (reset_close) {
+                ERROR("Call failed due to a connection problem, terminate execution... "
+                      "(use '-reconnect_close false' option to ignore)");
+            } else {
+                WARNING("Call failed due to a connection problem and abnormally terminated");
+                return false;
+            }
         }
 
         if(send_status < 0 && errno == EWOULDBLOCK) {


### PR DESCRIPTION
Right now the sipp exits abnormally when a connection (TCP/TLS) to UAS is refused. It might happen for "multi-socket" mode (tn/ln), and somebody may want to ignore the error and continue. I propose to bind it to the "-reconnect_close" option (default behavior won't change)