### PR TITLE
Fix crash

### DIFF
--- a/src/rtpstream.cpp
+++ b/src/rtpstream.cpp
@@ -1807,7 +1807,9 @@ static int rtpstream_get_localport(int* rtpsocket, int* rtcpsocket)
 
     debugprint("rtpstream_get_localport\n");
 
-    next_rtp_port = min_rtp_port;
+    if (!next_rtp_port) {
+        next_rtp_port = min_rtp_port;
+    }
 
     /* initialise address family and IP address for media socket */
     memset(&address, 0, sizeof(address));

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -388,12 +388,16 @@ int scenario::find_var(const char *varName)
 
 void scenario::addRtpTaskThreadID(pthread_t id)
 {
-    threadIDs[id] = "threadID";
+    if (id) {
+        threadIDs[id] = "threadID";
+    }
 }
 
 void scenario::removeRtpTaskThreadID(pthread_t id)
 {
-    threadIDs.erase(id);
+    if (id) {
+        threadIDs.erase(id);
+    }
 }
 
 std::unordered_map<pthread_t, std::string>& scenario::fetchRtpTaskThreadIDs()


### PR DESCRIPTION
When reusing the RTP thread, a thread with ID=0 may be added to the threadIDs.
This causes to pthread_join() on 0 when shutdown RTP stream,
leading to the program crash and failure to write screen logs, etc.