### PR TITLE
Make static-builds work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.4)
 
 # set the project name
 project(SIPp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ CHECK_SYMBOL_EXISTS(le16toh "sys/endian.h" HAVE_DECL_LE16TOH_BSD)
 configure_file("${PROJECT_SOURCE_DIR}/include/config.h.in"
                "${PROJECT_BINARY_DIR}/config.h" )
 
+if(BUILD_STATIC)
+  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+endif(BUILD_STATIC)
+
 list(REMOVE_ITEM all_SRCS
   "${PROJECT_SOURCE_DIR}/src/sipp_unittest.cpp")
 
@@ -155,10 +160,6 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/.git)
   add_dependencies(sipp version)
   add_dependencies(sipp_unittest version)
 endif()
-
-if(BUILD_STATIC)
-  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
-endif(BUILD_STATIC)
 
 if(PKG_CONFIG_FOUND)
   pkg_search_module(CURSES_LIBRARY ncursesw cursesw ncurses curses)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ and for now, it only works on Alpine Linux.
 
 To build a static binary, pass `-DBUILD_STATIC=1` to cmake.
 
+Two Alpine-based `Dockerfile`s are provided, which can be used as a
+build-environment.  Use either `Dockerfile` or `Dockerfile.full` in
+the following commands:
+
+```
+git submodule update --init
+docker build -t sipp-build -f docker/Dockerfile docker
+docker run --rm -v $PWD:/src sipp-build
+```
+
 # Support
 
 I try and be responsive to issues raised on Github, and there's [a

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -1,0 +1,28 @@
+FROM alpine:3.13
+
+RUN apk add --no-cache \
+  binutils \
+  make \
+  cmake \
+  gcc \
+  g++ \
+  ncurses-dev \
+  ncurses-static \
+  libpcap-dev \
+  gsl-dev \
+  gsl-static \
+  openssl-dev \
+  openssl-libs-static \
+  linux-headers \
+  lksctp-tools-dev \
+  lksctp-tools-static
+
+CMD cd /src \
+  && rm -f CMakeCache.txt \
+  && cmake . -DBUILD_STATIC=1 -DUSE_PCAP=1 -DUSE_GSL=1 -DUSE_SSL=1 -DUSE_SCTP=1 \
+  && make
+
+# Usage (from within the git repo):
+#   git submodule update --init
+#   docker build -t sipp-build -f docker/Dockerfile.full docker
+#   docker run -v $PWD:/src sipp-build


### PR DESCRIPTION
Resolves #514 

CMake 3.4 changes default behavior regarding static builds as part of https://cmake.org/cmake/help/latest/policy/CMP0065.html

Simply bumping the `cmake_minimum_required` value to `3.4` allows static-builds to work correctly.

Also note that Alpine has an incorrect `ldd` and `file` implementation which will still show the output executable as dynamic even though it is `static-pie`.  You can confirm the output is static by using `ldd` or `file` from Debian rather than from Alpine to inspect it.