### PR TITLE
fix verifyauth of passing empty auth when calling function verifyAuthHeader

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -5889,6 +5889,7 @@ call::T_ActionResult call::executeAction(const char* msg, message* curmsg)
                 result = false;
             } else {
                 char *auth = get_header(msg, "Authorization:", true);
+                auth = strdup(auth); // make a copy to avoid later get_header function call(clear its content)
                 char *method = (char *)malloc(end - msg + 1);
                 strncpy(method, msg, end - msg);
                 method[end - msg] = '\0';
@@ -5915,6 +5916,7 @@ call::T_ActionResult call::executeAction(const char* msg, message* curmsg)
                 free(username);
                 free(password);
                 free(method);
+                free(auth);
             }
 
             M_callVariableTable->getVar(currentAction->getVarId())->setBool(result);


### PR DESCRIPTION
The`get_header` function is using a static variable `last_header`, which stores the parsed header or content. 
At every function call the variable `last_header` is first cleared and  then put the newly parsed header or content.

This will cause problem if we use `get_header` to return a data buffer, before really using it, another `get_header` call comes. 

In this case, before we call `verifyAuthHeader` which really use the data buffer, there is a call to `createSendingMessage` which will call `get_header_content` which finally call `get_header`.