### PR TITLE
Add the IPs and remote address family to 'Network family mismatch' log

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2385,7 +2385,7 @@ int open_connections()
               switch (ret) {
 #ifdef EAI_ADDRFAMILY
                 case EAI_ADDRFAMILY:
-                    ERROR("Network family mismatch for local and remote IP");
+                    ERROR("Network family mismatch for local (%s) and remote (%s, %d) IP", local_ip, remote_ip, family_hint);
                     break;
 #endif
                 default:


### PR DESCRIPTION
https://github.com/SIPp/sipp/issues/612 shows that this can be hard to debug. We have local string variables for the local and remote IP, and we've determined the address family of the remote IP to use as a hint, so we should print those out to aid debugging.

```
$ ./sipp -sn uac -t t1 -i ::1 -r 3000 127.0.0.1                               
Resolving remote host '127.0.0.1'... Done.
                                          2023-04-01	09:39:39.426738	1680338379.426738: Network family mismatch for local (::1) and remote (127.0.0.1, 2) IP
------------------------------ Scenario Screen -------- [1-9]: Change Screen --
  Call rate (length)   Port   Total-time  Total-calls  Remote-host
  3000.0(0 ms)/1.000s   0          0.00 s            0  127.0.0.1:5060(TCP)

  0 new calls during 0.000 s period       0 ms scheduler resolution            
  0 calls (limit 9000)                    Peak was 0 calls, after 0 s
  0 Running, 0 Paused, 0 Woken up
  0 dead call msg (discarded)             0 out-of-call msg (discarded)
  0 open sockets                          0/0/0 TCP errors (send/recv/cong)

                                 Messages  Retrans   Timeout   Unexpected-Msg
0 :      INVITE ---------->         0         0         0                      
1 :         100 <----------         0         0         0         0            
2 :         180 <----------         0         0         0         0            
3 :         183 <----------         0         0         0         0            
4 :         200 <----------  E-RTD1 0         0         0         0            
5 :         ACK ---------->         0         0                                
6 :       Pause [      0ms]         0                             0        
7 :         BYE ---------->         0         0         0                      
8 :         200 <----------         0         0         0         0            

------------------------------ Test Terminated --------------------------------
----------------------------- Statistics Screen ------- [1-9]: Change Screen --
  Start Time             | 2023-04-01	09:39:39.423492	1680338379.423492         
  Last Reset Time        | 2023-04-01	09:39:39.423492	1680338379.423492         
  Current Time           | 2023-04-01	09:39:39.428057	1680338379.428057         
-------------------------+---------------------------+--------------------------
  Counter Name           | Periodic value            | Cumulative value
-------------------------+---------------------------+--------------------------
  Elapsed Time           | 00:00:00:004000           | 00:00:00:004000          
  Call Rate              |    0.000 cps              |    0.000 cps             
-------------------------+---------------------------+--------------------------
  Incoming calls created |        0                  |        0                 
  Outgoing calls created |        0                  |        0                 
  Total Calls created    |                           |        0                 
  Current Calls          |        0                  |                          
-------------------------+---------------------------+--------------------------
  Successful call        |        0                  |        0                 
  Failed call            |        0                  |        0                 
-------------------------+---------------------------+--------------------------
  Response Time 1        | 00:00:00:000000           | 00:00:00:000000          
  Call Length            | 00:00:00:000000           | 00:00:00:000000          
------------------------------ Test Terminated --------------------------------
2023-04-01	09:39:39.426738	1680338379.426738: Network family mismatch for local (::1) and remote (127.0.0.1, 2) IP
```