### PR TITLE
Make clock tick updates an explicit action to resolve race condition

### DIFF
--- a/include/time.hpp
+++ b/include/time.hpp
@@ -25,4 +25,6 @@ unsigned long getmilliseconds();
 unsigned long long getmicroseconds();
 void sipp_usleep(unsigned long usec);
 
+void update_clock_tick();
+
 #endif /* __SIPP_TIME_H__ */

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -2111,7 +2111,7 @@ bool call::run()
         return false;
     }
 
-    getmilliseconds();
+    update_clock_tick();
 
     message *curmsg;
     if (initCall) {
@@ -4490,7 +4490,7 @@ bool call::process_incoming(const char* msg, const struct sockaddr_storage* src)
     T_ActionResult  actionResult;
     unsigned long int invite_cseq = 0;
 
-    getmilliseconds();
+    update_clock_tick();
     callDebug("Processing %zu byte incoming message for call-ID %s (hash %lu):\n%s\n\n",
               strlen(msg), id, hash(msg), msg);
 

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -465,7 +465,7 @@ static void traffic_thread(int &rtp_errors, int &echo_errors)
     char L_file_name[MAX_PATH];
     sprintf(L_file_name, "%s_%ld_screen.log", scenario_file, (long) getpid());
 
-    getmilliseconds();
+    update_clock_tick();
 
     /* Arm the global timer if needed */
     if (global_timeout > 0) {
@@ -480,7 +480,7 @@ static void traffic_thread(int &rtp_errors, int &echo_errors)
 
     while (1) {
         scheduling_loops++;
-        getmilliseconds();
+        update_clock_tick();
 
         if (signalDump) {
             /* Screen dumping in a file */
@@ -540,7 +540,7 @@ static void traffic_thread(int &rtp_errors, int &echo_errors)
             }
         }
 
-        getmilliseconds();
+        update_clock_tick();
 
         /* Schedule all pending calls and process their timers */
         task_list *running_tasks;
@@ -593,8 +593,7 @@ static void traffic_thread(int &rtp_errors, int &echo_errors)
             sockets_pending_reset.erase(sockets_pending_reset.begin());
         }
 
-        /* Update the clock. */
-        getmilliseconds();
+        update_clock_tick();
         /* Receive incoming messages */
         SIPpSocket::pollset_process(running_tasks->empty());
     }

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2821,7 +2821,7 @@ void SIPpSocket::pollset_process(int wait)
 
     /* We need to process any messages that we have left over. */
     while (pending_messages && loops > 0) {
-        getmilliseconds();
+        update_clock_tick();
         if (sockets[read_index]->ss_msglen) {
             struct sockaddr_storage src;
             char msg[SIPP_MAX_MSG_SIZE];
@@ -2974,7 +2974,7 @@ void SIPpSocket::pollset_process(int wait)
 
 #ifdef HAVE_EPOLL
         unsigned old_pollnfds = pollnfds;
-        getmilliseconds();
+        update_clock_tick();
         /* Keep processing messages until this socket is freed (changing the number of file descriptors) or we run out of messages. */
         while ((pollnfds == old_pollnfds) &&
                 (sock->message_ready())) {
@@ -3014,7 +3014,7 @@ void SIPpSocket::pollset_process(int wait)
 
     /* We need to process any new messages that we read. */
     while (pending_messages && (loops > 0)) {
-        getmilliseconds();
+        update_clock_tick();
 
         if (sockets[read_index]->ss_msglen) {
             char msg[SIPP_MAX_MSG_SIZE];

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -79,10 +79,11 @@ unsigned long long getmicroseconds()
     }
     microseconds = microseconds - start_time;
 
-    // Static global from sipp.hpp
-    clock_tick = microseconds / MICROSECONDS_PER_MILLISECOND;
-
     return microseconds;
+}
+
+void update_clock_tick() {
+    clock_tick = getmilliseconds();
 }
 
 // Returns the number of milliseconds that have passed since SIPp

--- a/src/watchdog.cpp
+++ b/src/watchdog.cpp
@@ -52,7 +52,7 @@ watchdog::watchdog(int interval, int reset_interval, int major_threshold, int ma
 
 bool watchdog::run()
 {
-    getmilliseconds();
+    update_clock_tick();
 
     unsigned expected_major_trigger_time = last_fire + this->major_threshold;
     unsigned expected_minor_trigger_time = last_fire + this->minor_threshold;


### PR DESCRIPTION
I think I have a theory for why https://github.com/SIPp/sipp/issues/280 is happening (why time sometimes seems to move backwards).

Assume two threads are calling getmicroseconds().

- Thread 1 reaches https://github.com/SIPp/sipp/blob/master/src/time.cpp#L76 and sets microseconds = 999
- Thread 2 reaches https://github.com/SIPp/sipp/blob/master/src/time.cpp#L76 and sets microseconds = 1000
- Thread 2 reaches https://github.com/SIPp/sipp/blob/master/src/time.cpp#L83 and sets clock_tick = microseconds / 1000 = 1000/1000 = 1
- wheel_base is set to clock_tick (1)
- Thread 1 reaches https://github.com/SIPp/sipp/blob/master/src/time.cpp#L83 and sets clock_tick = microseconds / 1000 = 999/1000 = 0
- wheel_base (1) is now greater than clock_tick (0)

My proposed fix here is to make the clock_tick update an explicit function, not a side-effect of getting the time. I've assumed that all the places where we call `getmilliseconds()` and throw away the result are intended to update the clock_tick.

The risks are that:

- this updates the clock_tick too infrequently
- not all these places are on the same thread

I've tested this with a `std::cerr << "Updated clock_tick to " << local_clock_tick << " on thread " << std::this_thread::get_id() << std::endl;` log to confirm that:
- the clock_tick increments every 3 or 4 milliseconds in both the old and new cases
- the thread ID is always the same
