### PR TITLE
Give clear error if multiple command-line parameters are being interpreted as remote_host

### DIFF
--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -1381,6 +1381,9 @@ int main(int argc, char *argv[])
             struct sipp_option *option = find_option(argv[argi]);
             if (!option) {
                 if (argv[argi][0] != '-') {
+                    if ((pass == 0) && (remote_host[0] != 0)) {
+                        ERROR("remote_host given multiple times on command-line (%s and %s)", remote_host, argv[argi]);
+                    }
                     strncpy(remote_host, argv[argi], sizeof(remote_host) - 1);
                     continue;
                 }


### PR DESCRIPTION
Tested:

```
17:41:04 > $ ./sipp -m 1 -sn uac rtp.xml 127.0.0.8
2023-04-01	17:41:12.114369	1680367272.114369: remote_host given multiple times on command-line (rtp.xml and 127.0.0.8)
2023-04-01	17:41:12.114369	1680367272.114369: remote_host given multiple times on command-line (rtp.xml and 127.0.0.8)
```

and the non-error case:

```
17:46:28 > $ ./sipp -m 1 -sf rtp.xml 127.0.0.8
Resolving remote host '127.0.0.8'... Done.
------------------------------ Scenario Screen -------- [1-9]: Change Screen --
  Call rate (length)   Port   Total-time  Total-calls  Remote-host
  10.0(0 ms)/1.000s   5060       0.10 s            1  127.0.0.8:5060(UDP)
````

(Inspired by #564)
