### PR TITLE
Add git to the static build Dockerfiles, so that version.h is generated correctly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.10
 
-RUN apk add --no-cache binutils make cmake gcc g++ ncurses-static libpcap-dev ncurses-dev gsl-dev
+RUN apk add --no-cache binutils make cmake gcc g++ ncurses-static libpcap-dev ncurses-dev gsl-dev git
 
 CMD cd /src && rm -f CMakeCache.txt && cmake . -DBUILD_STATIC=1 -DUSE_PCAP=1 -DUSE_GSL=1 && make 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -6,6 +6,7 @@ RUN apk add --no-cache \
   cmake \
   gcc \
   g++ \
+  git \
   ncurses-dev \
   ncurses-static \
   libpcap-dev \


### PR DESCRIPTION
I made this change locally when preparing 3.7.0.