### PR TITLE
Allow build to proceed if gtest is missing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Bugs fixed in 3.7.1
+=======================
+
+- Correctly open the control socket
+- The SIPp binary can now be built even when the `gtest` checkout is missing
+- rtpstream files are now also found next to the scenario. If it is not found there, it will be treated as a relative path as usual.
+
 Features added in 3.7.0
 ===========================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,20 +124,27 @@ endif(USE_SCTP)
 link_directories("/usr/local/lib")
 add_executable(sipp ${all_SRCS} "${PROJECT_SOURCE_DIR}/src/sipp.cpp")
 target_compile_features(sipp PUBLIC cxx_auto_type cxx_range_for)
-add_executable(sipp_unittest EXCLUDE_FROM_ALL
-  ${all_SRCS}
-  "${PROJECT_SOURCE_DIR}/src/sipp_unittest.cpp"
-  "${PROJECT_SOURCE_DIR}/gtest/googletest/src/gtest-all.cc"
-  "${PROJECT_SOURCE_DIR}/gtest/googlemock/src/gmock-all.cc"
-)
-target_compile_features(sipp_unittest PUBLIC cxx_auto_type cxx_range_for)
-target_compile_definitions(sipp_unittest PUBLIC "-DGTEST")
-target_include_directories(sipp_unittest SYSTEM PUBLIC
-  ${PROJECT_SOURCE_DIR}/gtest/googletest
-  ${PROJECT_SOURCE_DIR}/gtest/googlemock
-  ${PROJECT_SOURCE_DIR}/gtest/googletest/include
-  ${PROJECT_SOURCE_DIR}/gtest/googlemock/include
-)
+
+if(EXISTS ${PROJECT_SOURCE_DIR}/gtest/googletest)
+  add_executable(sipp_unittest EXCLUDE_FROM_ALL
+    ${all_SRCS}
+    "${PROJECT_SOURCE_DIR}/src/sipp_unittest.cpp"
+    "${PROJECT_SOURCE_DIR}/gtest/googletest/src/gtest-all.cc"
+    "${PROJECT_SOURCE_DIR}/gtest/googlemock/src/gmock-all.cc"
+  )
+  target_compile_features(sipp_unittest PUBLIC cxx_auto_type cxx_range_for)
+  target_compile_definitions(sipp_unittest PUBLIC "-DGTEST")
+  target_include_directories(sipp_unittest SYSTEM PUBLIC
+    ${PROJECT_SOURCE_DIR}/gtest/googletest
+    ${PROJECT_SOURCE_DIR}/gtest/googlemock
+    ${PROJECT_SOURCE_DIR}/gtest/googletest/include
+    ${PROJECT_SOURCE_DIR}/gtest/googlemock/include
+  )
+else()
+  add_executable(sipp_unittest EXCLUDE_FROM_ALL
+    ${all_SRCS}
+    "${PROJECT_SOURCE_DIR}/src/sipp_unittest.cpp")
+endif()
 
 # add version
 find_package(Git)


### PR DESCRIPTION
Fixes #637 and #626 .

If `gtest` is missing, you can now build the sipp binary. sipp_unittest still depends on gtest, and attempts to build that with it missing will fail with:

```
/home/rkd/src/sipp/src/sipp_unittest.cpp:22:10: fatal error: gtest/gtest.h: No such file or directory
   22 | #include "gtest/gtest.h"
      |          ^~~~~~~~~~~~~~~
compilation terminated.
```