### PR TITLE
Ims ipsec support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,4 +252,6 @@ if(USE_SCTP)
   endif()
 endif()
 
+add_subdirectory(calc_keys)
+
 install(TARGETS sipp DESTINATION bin)

--- a/calc_keys/CMakeLists.txt
+++ b/calc_keys/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.4)
+
+# set the project name
+project(SIPp)
+
+# specify the C++ standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS False)
+# specify the C++ standard on older CMake (<3.8)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+
+add_executable(calc_ck calc_ck.cpp ../src/milenage.c ../src/md5.c ../src/rijndael.c ../src/strings.cpp)
+target_include_directories(calc_ck PRIVATE ../include)

--- a/calc_keys/calc_ck.cpp
+++ b/calc_keys/calc_ck.cpp
@@ -1,0 +1,122 @@
+//
+// Created by dbori on 18.06.2023.
+//
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include "auth.hpp"
+#include "milenage.h"
+#include "strings.hpp"
+
+#define STR_K_LEN (CKLEN * 2 + 2 + 1)
+typedef char STR_KEY[STR_K_LEN];
+
+char digit_to_hex(const char c) {
+	if (c > 15 || c < 0)
+		return 0;
+	if (c > 9)
+		return 'a' + c - 10;
+	return '0' + c;
+}
+
+void key_to_hex(const CK key, STR_KEY res) {
+	bzero(res, STR_K_LEN);
+	int i = 2;
+	res[0] = '0';
+	res[1] = 'x';
+	while (i < STR_K_LEN - 1) {
+		res[i] = digit_to_hex(key[(i - 2) / 2] >> 4);
+		res[i + 1] = digit_to_hex(key[(i - 2) / 2] & 0x0f);
+		i += 2;
+	}
+	res[STR_K_LEN - 1] = '\0';
+}
+
+void parse_key_str(const char *key_str, K key, size_t key_len) {
+	size_t pos;
+	bzero(key, key_len);
+	size_t len = strlen(key_str);
+	if (key_str[0] == '0' && key_str[1] == 'x') {
+		pos = 2;
+		while (pos < strlen(key_str)) {
+			if (key_str[pos] == '\0')
+				break;
+			if (!(pos % 2))
+				key[pos / 2 - 1] += get_decimal_from_hex(key_str[pos]) << 4;
+			else
+				key[pos / 2 - 1] += get_decimal_from_hex(key_str[pos]);
+			pos++;
+		}
+		return;
+	} else if (len && key_str[0] == '"' && key_str[len - 1] == '"') {
+		int pos_s = 1, pos_k = 0;
+		while (pos_s < len - 1 && pos_k < key_len) {
+			if (key_str[pos_s] != '\\')
+				key[pos_k] = key_str[pos_s];
+			else
+				++pos_s;
+			++pos_s;
+			++pos_k;
+		}
+		return;
+	} else {
+		int pos_s = 0, pos_k = 0;
+		while (pos_s < len && pos_k < key_len) {
+			if (key_str[pos_s] != '\\')
+				key[pos_k] = key_str[pos_s];
+			else
+				++pos_s;
+			++pos_s;
+			++pos_k;
+		}
+	}
+}
+
+int main(int argc, char *argv[]) {
+	OP op;
+	RAND rnd;
+	K k;
+	RES res;
+	AK ak;
+	CK ck;
+	IK ik;
+
+
+	if (argc != 5)
+		exit(-1);
+	if (!strcmp(argv[3], "null")) {
+		std::cout << "''";
+		exit(0);
+	}
+	int nonce_len;
+	auto nonce = base64_decode_string(argv[2], strlen(argv[2]), &nonce_len);
+
+	if (nonce_len < RANDLEN + AUTNLEN) {
+		if (nonce)
+			free(nonce);
+		std::cerr << "Incorrect length of nonce, expected " << RANDLEN + AUTNLEN << std::endl;
+		exit(-1);
+	}
+
+	memcpy(rnd, nonce, RANDLEN);
+	parse_key_str(argv[1], k, sizeof k);
+	parse_key_str(argv[4], op, sizeof op);
+
+	bzero(op, sizeof op);
+	bzero(ak, sizeof ak);
+
+	f2345(k, rnd, res, ck, ik, ak, op);
+	if (strstr(argv[0], "calc_ck")) {
+		STR_KEY s_ck;
+		key_to_hex(ck, s_ck);
+		std::cout << s_ck;
+	} else if (strstr(argv[0], "calc_ik")) {
+		STR_KEY s_ik;
+		key_to_hex(ik, s_ik);
+		std::cout << s_ik;
+	} else {
+		std::cout << "Program should be called as 'calc_ck' or 'calc_ik' but called as " << argv[0] << std::endl;
+		exit(-1);
+	}
+}

--- a/include/actions.hpp
+++ b/include/actions.hpp
@@ -32,7 +32,7 @@ class CSample;
 #endif
 #include "rtpstream.hpp"
 
-#define MAX_ACTION_MESSAGE 3
+#define MAX_ACTION_MESSAGE 4
 
 class CAction
 {
@@ -68,6 +68,7 @@ public:
         E_AT_VAR_URLENCODE,
         E_AT_VERIFY_AUTH,
         E_AT_SET_DEST,
+        E_AT_SET_DEST_W_SPORT,
         E_AT_CLOSE_CON,
 #ifdef PCAPPLAY
         E_AT_PLAY_PCAP_AUDIO,

--- a/include/auth.hpp
+++ b/include/auth.hpp
@@ -14,20 +14,236 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-int createAuthHeader(const char *user,
-                     const char *password,
-                     const char *method,
-                     const char *uri,
-                     const char *msgbody,
-                     const char *auth,
-                     const char *aka_OP,
-                     const char *aka_AMF,
-                     const char *aka_K,
-                     unsigned int nonce_count,
-                     char *result,
-                     size_t result_len);
+#pragma once
+
+#define CKLEN 16
+typedef u_char CK[CKLEN];
+#define IKLEN 16
+typedef u_char IK[IKLEN];
+
+/* AKA */
+
+#define KLEN 16
+typedef u_char K[KLEN];
+#define RANDLEN 16
+typedef u_char RAND[RANDLEN];
+#define AUTNLEN 16
+typedef u_char AUTN[AUTNLEN];
+
+#define AKLEN 6
+typedef u_char AK[AKLEN];
+#define AMFLEN 2
+typedef u_char AMF[AMFLEN];
+#define MACLEN 8
+typedef u_char MAC[MACLEN];
+#define SQNLEN 6
+typedef u_char SQN[SQNLEN];
+#define AUTSLEN 14
+typedef char AUTS[AUTSLEN];
+#define AUTS64LEN 29
+typedef char AUTS64[AUTS64LEN];
+#define RESLEN 8
+typedef unsigned char RES[RESLEN + 1];
+#define RESHEXLEN 17
+typedef char RESHEX[RESHEXLEN];
+#define OPLEN 16
+typedef u_char OP[OPLEN];
+
+//AMF amfstar="\0";
+
+/* end AKA */
+
+int createAuthHeader(const char *user, const char *password, const char *method, const char *uri, const char *msgbody,
+                     const char *auth, const char *aka_OP, const char *aka_AMF, const char *aka_K,
+                     unsigned int nonce_count, char *result, size_t result_len, CK ck, IK ik);
+
 int verifyAuthHeader(const char *user, const char *password,
                      const char *method, const char *auth,
                      const char *msgbody);
+
 int getAuthParameter(const char *name, const char *header, char *result,
                      int len);
+
+static char base64[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/*"
+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";*/
+static int base64_val(char x) {
+	switch(x) {
+		case '=':
+			return -1;
+		case 'A':
+			return 0;
+		case 'B':
+			return 1;
+		case 'C':
+			return 2;
+		case 'D':
+			return 3;
+		case 'E':
+			return 4;
+		case 'F':
+			return 5;
+		case 'G':
+			return 6;
+		case 'H':
+			return 7;
+		case 'I':
+			return 8;
+		case 'J':
+			return 9;
+		case 'K':
+			return 10;
+		case 'L':
+			return 11;
+		case 'M':
+			return 12;
+		case 'N':
+			return 13;
+		case 'O':
+			return 14;
+		case 'P':
+			return 15;
+		case 'Q':
+			return 16;
+		case 'R':
+			return 17;
+		case 'S':
+			return 18;
+		case 'T':
+			return 19;
+		case 'U':
+			return 20;
+		case 'V':
+			return 21;
+		case 'W':
+			return 22;
+		case 'X':
+			return 23;
+		case 'Y':
+			return 24;
+		case 'Z':
+			return 25;
+		case 'a':
+			return 26;
+		case 'b':
+			return 27;
+		case 'c':
+			return 28;
+		case 'd':
+			return 29;
+		case 'e':
+			return 30;
+		case 'f':
+			return 31;
+		case 'g':
+			return 32;
+		case 'h':
+			return 33;
+		case 'i':
+			return 34;
+		case 'j':
+			return 35;
+		case 'k':
+			return 36;
+		case 'l':
+			return 37;
+		case 'm':
+			return 38;
+		case 'n':
+			return 39;
+		case 'o':
+			return 40;
+		case 'p':
+			return 41;
+		case 'q':
+			return 42;
+		case 'r':
+			return 43;
+		case 's':
+			return 44;
+		case 't':
+			return 45;
+		case 'u':
+			return 46;
+		case 'v':
+			return 47;
+		case 'w':
+			return 48;
+		case 'x':
+			return 49;
+		case 'y':
+			return 50;
+		case 'z':
+			return 51;
+		case '0':
+			return 52;
+		case '1':
+			return 53;
+		case '2':
+			return 54;
+		case '3':
+			return 55;
+		case '4':
+			return 56;
+		case '5':
+			return 57;
+		case '6':
+			return 58;
+		case '7':
+			return 59;
+		case '8':
+			return 60;
+		case '9':
+			return 61;
+		case '+':
+			return 62;
+		case '/':
+			return 63;
+	}
+	return 0;
+}
+
+static char *base64_decode_string(const char *buf, unsigned int len, int *newlen) {
+	unsigned long i;
+	int j, x1, x2, x3, x4;
+	char *out;
+	out = (char *) malloc((len * 3 / 4) + 8);
+	for (i = 0, j = 0; i + 3 < len; i += 4) {
+		x1 = base64_val(buf[i]);
+		x2 = base64_val(buf[i + 1]);
+		x3 = base64_val(buf[i + 2]);
+		x4 = base64_val(buf[i + 3]);
+		out[j++] = (x1 << 2) | ((x2 & 0x30) >> 4);
+		out[j++] = ((x2 & 0x0F) << 4) | ((x3 & 0x3C) >> 2);
+		out[j++] = ((x3 & 0x03) << 6) | (x4 & 0x3F);
+	}
+	if (i < len) {
+		x1 = base64_val(buf[i]);
+		if (i + 1 < len)
+			x2 = base64_val(buf[i + 1]);
+		else
+			x2 = -1;
+		if (i + 2 < len)
+			x3 = base64_val(buf[i + 2]);
+		else
+			x3 = -1;
+		if (i + 3 < len)
+			x4 = base64_val(buf[i + 3]);
+		else x4 = -1;
+		if (x2 != -1) {
+			out[j++] = (x1 << 2) | ((x2 & 0x30) >> 4);
+			if (x3 == -1) {
+				out[j++] = ((x2 & 0x0F) << 4) | ((x3 & 0x3C) >> 2);
+				if (x4 == -1) {
+					out[j++] = ((x3 & 0x03) << 6) | (x4 & 0x3F);
+				}
+			}
+		}
+
+	}
+
+	out[j++] = 0;
+	*newlen = j;
+	return out;
+}

--- a/include/call.hpp
+++ b/include/call.hpp
@@ -41,6 +41,7 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 #include "sip_parser.hpp"
+#include "auth.hpp"
 
 #define UDP_MAX_RETRANS_INVITE_TRANSACTION 5
 #define UDP_MAX_RETRANS_NON_INVITE_TRANSACTION 9
@@ -260,7 +261,11 @@ protected:
     /* call to continue and mark it as failed */
     T_ActionResult last_action_result;
 
-    /* rc == true means call not deleted by processing */
+	/* ck_key and ik_key from AKA authentication that can be used to create ipsec association via external command */
+	CK _ck;
+	IK _ik;
+
+	/* rc == true means call not deleted by processing */
     void formatNextReqUrl(const char* contact);
     void computeRouteSetAndRemoteTargetUri(const char* rrList, const char* contact, bool bRequestIncoming);
     bool matches_scenario(unsigned int index, int reply_code, char * request, char * responsecseqmethod, char *txn);

--- a/include/message.hpp
+++ b/include/message.hpp
@@ -88,6 +88,8 @@ typedef enum {
     E_Message_Custom,
     E_Message_RTPStream_Audio_Port,
     E_Message_RTPStream_Video_Port,
+    E_Message_CKey,
+    E_Message_IKey,
 #ifdef USE_TLS
     E_Message_CryptoTag1Audio,
     E_Message_CryptoTag2Audio,

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -54,7 +54,7 @@ int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,
                     unsigned short port, int flags, int family);
 int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,
                     const char *service, int flags, int family);
-void sockaddr_update_port(struct sockaddr_storage* ss, short port);
+void sockaddr_update_port(struct sockaddr_storage* ss, unsigned short port);
 
 
 /* This is an abstraction of a socket, which provides buffers for input and

--- a/sipp.dtd
+++ b/sipp.dtd
@@ -76,8 +76,9 @@
 <!ATTLIST ereg check_it (true|false) "false" >
 <!ATTLIST ereg header NMTOKEN #IMPLIED >
 <!ATTLIST ereg regexp CDATA #REQUIRED >
-<!ATTLIST ereg search_in (msg|hdr) "msg" >
+<!ATTLIST ereg search_in (msg|hdr|var) "msg" >
 <!ATTLIST ereg start_line (true|false) #IMPLIED >
+<!ATTLIST ereg variable CDATA #IMPLIED >
 
 <!ELEMENT log EMPTY >
 <!ATTLIST log message CDATA #REQUIRED >
@@ -108,9 +109,57 @@
 <!ATTLIST test value CDATA #REQUIRED >
 <!ATTLIST test variable CDATA #REQUIRED >
 
+<!ELEMENT assignstr EMPTY >
+<!ATTLIST assignstr assign_to CDATA #REQUIRED >
+<!ATTLIST assignstr value CDATA #REQUIRED >
+
 <!ELEMENT assign EMPTY >
 <!ATTLIST assign assign_to CDATA #REQUIRED >
-<!ATTLIST assign variable CDATA #REQUIRED >
+<!ATTLIST assign value CDATA #IMPLIED >
+<!ATTLIST assign variable CDATA #IMPLIED >
+
+<!ELEMENT gettimeofday EMPTY >
+<!ATTLIST gettimeofday assign_to CDATA #REQUIRED >
+
+<!ELEMENT insert EMPTY >
+<!ATTLIST insert file CDATA #REQUIRED >
+<!ATTLIST insert value CDATA #REQUIRED >
+
+<!ELEMENT jump EMPTY>
+<!ATTLIST jump value CDATA #IMPLIED>
+<!ATTLIST jump variable CDATA #IMPLIED>
+
+<!ELEMENT lookup EMPTY>
+<!ATTLIST lookup assign_to CDATA #REQUIRED>
+<!ATTLIST lookup file CDATA #REQUIRED>
+<!ATTLIST lookup key CDATA #REQUIRED>
+
+<!ELEMENT replace EMPTY>
+<!ATTLIST replace value CDATA #REQUIRED>
+<!ATTLIST replace file CDATA #REQUIRED>
+<!ATTLIST replace line CDATA #REQUIRED>
+
+<!ELEMENT sample EMPTY>
+<!ATTLIST sample assign_to CDATA #REQUIRED>
+<!ATTLIST sample distribution CDATA #REQUIRED>
+<!ATTLIST sample mean CDATA #REQUIRED>
+<!ATTLIST sample stdev CDATA #REQUIRED>
+
+<!ELEMENT setdest EMPTY>
+<!ATTLIST setdest host CDATA #REQUIRED>
+<!ATTLIST setdest port CDATA #REQUIRED>
+<!ATTLIST setdest protocol CDATA #REQUIRED>
+<!ATTLIST setdest local_port CDATA #IMPLIED>
+
+<!ELEMENT todouble EMPTY>
+<!ATTLIST todouble assign_to CDATA #REQUIRED>
+<!ATTLIST todouble variable CDATA #IMPLIED>
+<!ATTLIST todouble value CDATA #IMPLIED>
+
+<!ELEMENT verifyauth EMPTY>
+<!ATTLIST verifyauth assign_to CDATA #REQUIRED>
+<!ATTLIST verifyauth username CDATA #REQUIRED>
+<!ATTLIST verifyauth password CDATA #REQUIRED>
 
 <!ELEMENT urldecode EMPTY >
 <!ATTLIST urldecode variable CDATA #REQUIRED >
@@ -125,3 +174,24 @@
 
 <!ELEMENT Reference EMPTY >
 <!ATTLIST Reference variables CDATA #REQUIRED >
+
+<!ELEMENT add EMPTY>
+<!ATTLIST add assign_to CDATA #REQUIRED>
+<!ATTLIST add value CDATA #IMPLIED>
+<!ATTLIST add variable CDATA #IMPLIED>
+
+<!ELEMENT subtract EMPTY>
+<!ATTLIST subtract assign_to CDATA #REQUIRED>
+<!ATTLIST subtract value CDATA #IMPLIED>
+<!ATTLIST subtract variable CDATA #IMPLIED>
+
+<!ELEMENT multiply EMPTY>
+<!ATTLIST multiply assign_to CDATA #REQUIRED>
+<!ATTLIST multiply value CDATA #IMPLIED>
+<!ATTLIST multiply variable CDATA #IMPLIED>
+
+<!ELEMENT divide EMPTY>
+<!ATTLIST divide assign_to CDATA #REQUIRED>
+<!ATTLIST divide value CDATA #IMPLIED>
+<!ATTLIST divide variable CDATA #IMPLIED>
+

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -703,6 +703,10 @@ static int createAuthHeaderAKAv1MD5(
     f2345(k, rnd, res, ck, ik, ak, op);
     res[RESLEN] = '\0';
 
+	/** todo
+	 * 	 create and export ck and ik keywords here
+	 */
+
     /* Compute sqn encoded in AUTN */
     for (i=0; i < SQNLEN; i++)
         sqn[i] = sqnxoraka[i] ^ ak[i];

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -39,43 +39,7 @@
 #define MD5_HASH_SIZE 16
 #define HASH_HEX_SIZE 2*MD5_HASH_SIZE
 
-/* AKA */
-
-#define KLEN 16
-typedef u_char K[KLEN];
-#define RANDLEN 16
-typedef u_char RAND[RANDLEN];
-#define AUTNLEN 16
-typedef u_char AUTN[AUTNLEN];
-
-#define AKLEN 6
-typedef u_char AK[AKLEN];
-#define AMFLEN 2
-typedef u_char AMF[AMFLEN];
-#define MACLEN 8
-typedef u_char MAC[MACLEN];
-#define CKLEN 16
-typedef u_char CK[CKLEN];
-#define IKLEN 16
-typedef u_char IK[IKLEN];
-#define SQNLEN 6
-typedef u_char SQN[SQNLEN];
-#define AUTSLEN 14
-typedef char AUTS[AUTSLEN];
-#define AUTS64LEN 29
-typedef char AUTS64[AUTS64LEN];
-#define RESLEN 8
-typedef unsigned char RES[RESLEN+1];
-#define RESHEXLEN 17
-typedef char RESHEX[RESHEXLEN];
-#define OPLEN 16
-typedef u_char OP[OPLEN];
-
-AMF amfstar="\0";
 SQN sqn_he= {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-
-/* end AKA */
-
 
 static int createAuthHeaderMD5(
     const char* user, const char* password, int password_len,
@@ -83,11 +47,10 @@ static int createAuthHeaderMD5(
     const char* auth, const char* algo, unsigned int nonce_count,
     char* result, size_t result_len);
 
-static int createAuthHeaderAKAv1MD5(
-    const char* user, const char* OP, const char* AMF, const char* K,
-    const char* method, const char* uri, const char* msgbody,
-    const char* auth, const char* algo, unsigned int nonce_count,
-    char* result, size_t result_len);
+static int createAuthHeaderAKAv1MD5(const char *user, const char *aka_OP, const char *aka_AMF, const char *aka_K,
+                                    const char *method, const char *uri, const char *msgbody, const char *auth,
+                                    const char *algo, unsigned int nonce_count, char *result, size_t result_len, CK ck,
+                                    IK ik);
 
 
 /* This function is from RFC 2617 Section 5 */
@@ -142,11 +105,9 @@ static char *stristr(const char* s1, const char* s2)
     return 0;
 }
 
-int createAuthHeader(
-    const char* user, const char* password, const char* method,
-    const char* uri, const char* msgbody, const char* auth,
-    const char* aka_OP, const char* aka_AMF, const char* aka_K,
-    unsigned int nonce_count, char* result, size_t result_len)
+int createAuthHeader(const char *user, const char *password, const char *method, const char *uri, const char *msgbody,
+                     const char *auth, const char *aka_OP, const char *aka_AMF, const char *aka_K,
+                     unsigned int nonce_count, char *result, size_t result_len, CK ck, IK ik)
 {
 
     char algo[32] = "MD5";
@@ -183,8 +144,8 @@ int createAuthHeader(
             return 0;
         }
         return createAuthHeaderAKAv1MD5(
-            user, aka_OP, aka_AMF, aka_K, method, uri, msgbody, auth,
-            algo, nonce_count, result, result_len);
+	        user, aka_OP, aka_AMF, aka_K, method, uri, msgbody, auth,
+	        algo, nonce_count, result, result_len, ck, ik);
     } else {
         snprintf(result, result_len, "createAuthHeader: authentication must use MD5 or AKAv1-MD5");
         return 0;
@@ -451,200 +412,12 @@ int verifyAuthHeader(const char *user, const char *password, const char *method,
     }
 }
 
-
-
-/*"
-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";*/
-static int base64_val(char x) {
-    switch(x) {
-    case '=':
-        return -1;
-    case 'A':
-        return 0;
-    case 'B':
-        return 1;
-    case 'C':
-        return 2;
-    case 'D':
-        return 3;
-    case 'E':
-        return 4;
-    case 'F':
-        return 5;
-    case 'G':
-        return 6;
-    case 'H':
-        return 7;
-    case 'I':
-        return 8;
-    case 'J':
-        return 9;
-    case 'K':
-        return 10;
-    case 'L':
-        return 11;
-    case 'M':
-        return 12;
-    case 'N':
-        return 13;
-    case 'O':
-        return 14;
-    case 'P':
-        return 15;
-    case 'Q':
-        return 16;
-    case 'R':
-        return 17;
-    case 'S':
-        return 18;
-    case 'T':
-        return 19;
-    case 'U':
-        return 20;
-    case 'V':
-        return 21;
-    case 'W':
-        return 22;
-    case 'X':
-        return 23;
-    case 'Y':
-        return 24;
-    case 'Z':
-        return 25;
-    case 'a':
-        return 26;
-    case 'b':
-        return 27;
-    case 'c':
-        return 28;
-    case 'd':
-        return 29;
-    case 'e':
-        return 30;
-    case 'f':
-        return 31;
-    case 'g':
-        return 32;
-    case 'h':
-        return 33;
-    case 'i':
-        return 34;
-    case 'j':
-        return 35;
-    case 'k':
-        return 36;
-    case 'l':
-        return 37;
-    case 'm':
-        return 38;
-    case 'n':
-        return 39;
-    case 'o':
-        return 40;
-    case 'p':
-        return 41;
-    case 'q':
-        return 42;
-    case 'r':
-        return 43;
-    case 's':
-        return 44;
-    case 't':
-        return 45;
-    case 'u':
-        return 46;
-    case 'v':
-        return 47;
-    case 'w':
-        return 48;
-    case 'x':
-        return 49;
-    case 'y':
-        return 50;
-    case 'z':
-        return 51;
-    case '0':
-        return 52;
-    case '1':
-        return 53;
-    case '2':
-        return 54;
-    case '3':
-        return 55;
-    case '4':
-        return 56;
-    case '5':
-        return 57;
-    case '6':
-        return 58;
-    case '7':
-        return 59;
-    case '8':
-        return 60;
-    case '9':
-        return 61;
-    case '+':
-        return 62;
-    case '/':
-        return 63;
-    }
-    return 0;
-}
-
-static char* base64_decode_string(const char* buf, unsigned int len, int* newlen)
-{
-    unsigned long i;
-    int j, x1, x2, x3, x4;
-    char *out;
-    out = (char *)malloc( ( len * 3/4 ) + 8 );
-    for(i=0, j=0; i + 3 < len; i += 4) {
-        x1=base64_val(buf[i]);
-        x2=base64_val(buf[i+1]);
-        x3=base64_val(buf[i+2]);
-        x4=base64_val(buf[i+3]);
-        out[j++]=(x1<<2) | ((x2 & 0x30)>>4);
-        out[j++]=((x2 & 0x0F)<<4) | ((x3 & 0x3C)>>2);
-        out[j++]=((x3 & 0x03)<<6) | (x4 & 0x3F);
-    }
-    if (i<len) {
-        x1 = base64_val(buf[i]);
-        if (i+1<len)
-            x2=base64_val(buf[i+1]);
-        else
-            x2=-1;
-        if (i+2<len)
-            x3=base64_val(buf[i+2]);
-        else
-            x3=-1;
-        if(i+3<len)
-            x4=base64_val(buf[i+3]);
-        else x4=-1;
-        if (x2!=-1) {
-            out[j++]=(x1<<2) | ((x2 & 0x30)>>4);
-            if (x3==-1) {
-                out[j++]=((x2 & 0x0F)<<4) | ((x3 & 0x3C)>>2);
-                if (x4==-1) {
-                    out[j++]=((x3 & 0x03)<<6) | (x4 & 0x3F);
-                }
-            }
-        }
-
-    }
-
-    out[j++] = 0;
-    *newlen=j;
-    return out;
-}
-
-char base64[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
 char hexa[17] = "0123456789abcdef";
 
-static int createAuthHeaderAKAv1MD5(
-    const char* user, const char* aka_OP, const char* aka_AMF,
-    const char* aka_K, const char* method, const char* uri,
-    const char* msgbody, const char* auth, const char* algo,
-    unsigned int nonce_count, char* result, size_t result_len)
+static int createAuthHeaderAKAv1MD5(const char *user, const char *aka_OP, const char *aka_AMF, const char *aka_K,
+                                    const char *method, const char *uri, const char *msgbody, const char *auth,
+                                    const char *algo, unsigned int nonce_count, char *result, size_t result_len, CK ck,
+                                    IK ik)
 {
 
     char tmp[MAX_HEADER_LEN];
@@ -662,8 +435,6 @@ static int createAuthHeaderAKAv1MD5(
     SQN sqn, sqnxoraka, sqn_ms;
     K k;
     RES res;
-    CK ck;
-    IK ik;
     AK ak;
     int i;
 
@@ -702,10 +473,6 @@ static int createAuthHeaderAKAv1MD5(
     /* Compute the AK, response and keys CK IK */
     f2345(k, rnd, res, ck, ik, ak, op);
     res[RESLEN] = '\0';
-
-	/** todo
-	 * 	 create and export ck and ik keywords here
-	 */
 
     /* Compute sqn encoded in AUTN */
     for (i=0; i < SQNLEN; i++)
@@ -806,7 +573,8 @@ TEST(DigestAuth, BasicVerification) {
                            " nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\"\r\n,"
                            " opaque=\"5ccc069c403ebaf9f0171e9517f40e41\""));
     char result[255];
-    createAuthHeader("testuser", "secret", "REGISTER", "sip:example.com", "hello world", header, NULL, NULL, NULL, 1, result, 255);
+	createAuthHeader("testuser", "secret", "REGISTER", "sip:example.com", "hello world", header, NULL, NULL, NULL, 1,
+	                 result, 255, nullptr, nullptr);
     EXPECT_STREQ("Digest username=\"testuser\",realm=\"testrealm@host.com\",uri=\"sip:sip:example.com\",nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\",response=\"db94e01e92f2b09a52a234eeca8b90f7\",algorithm=MD5,opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"", result);
     EXPECT_EQ(1, verifyAuthHeader("testuser", "secret", "REGISTER", result, "hello world"));
     free(header);
@@ -819,18 +587,18 @@ TEST(DigestAuth, qop) {
                            "\tqop=\"auth,auth-int\",\r\n"
                            "\tnonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\"\r\n,"
                            "\topaque=\"5ccc069c403ebaf9f0171e9517f40e41\""));
-    createAuthHeader("testuser",
-                     "secret",
-                     "REGISTER",
-                     "sip:example.com",
-                     "hello world",
-                     header,
-                     NULL,
-                     NULL,
-                     NULL,
-                     1,
-                     result,
-                     1024);
+	createAuthHeader("testuser",
+	                 "secret",
+	                 "REGISTER",
+	                 "sip:example.com",
+	                 "hello world",
+	                 header,
+	                 NULL,
+	                 NULL,
+	                 NULL,
+	                 1,
+	                 result,
+	                 1024, nullptr, nullptr);
     EXPECT_EQ(1, !!strstr(result, ",qop=auth-int,")); // no double quotes around qop-value
     EXPECT_EQ(1, verifyAuthHeader("testuser", "secret", "REGISTER", result, "hello world"));
     free(header);

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -2065,7 +2065,7 @@ bool call::executeMessage(message *curmsg)
             WARNING("Call-Id: %s, receive timeout on message %s:%d, jumping to label %d",
                     id, curmsg->desc, curmsg->index, curmsg->on_timeout);
             /* FIXME: We should do something like set index here, but it probably
-             * does not matter too much as only nops are allowed in the init stanza. */
+             *  does not matter too much as only nops are allowed in the init stanza. */
             msg_index = curmsg->on_timeout;
             recv_timeout = 0;
             if (msg_index < (int)call_scenario->messages.size()) return true;
@@ -4032,7 +4032,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             authlen = sprintf(result, "Proxy-Authorization: ");
         }
 
-        /* Build the auth credenticals */
+        /* Build the auth credentials */
         char uri[MAX_HEADER_LEN];
         sprintf (uri, "%s:%d", remote_ip, remote_port);
         /* These cause this function to  not be reentrant. */
@@ -5251,9 +5251,9 @@ bool call::process_incoming(const char* msg, const struct sockaddr_storage* src)
 
         found = true;
         /* TODO : this is a little buggy: If a 100 trying from an INVITE
-         * is delayed by the network until the BYE is sent, it may
-         * stop BYE transmission erroneously, if the BYE also expects
-         * a 100 trying. */
+         *  is delayed by the network until the BYE is sent, it may
+         *  stop BYE transmission erroneously, if the BYE also expects
+         *  a 100 trying. */
         break;
     }
 

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -118,6 +118,8 @@ struct KeywordMap SimpleKeywords[] = {
     {"timestamp", E_Message_Timestamp },
     {"date", E_Message_Date },
     {"sipp_version", E_Message_SippVersion },
+    {"ck_key", E_Message_CKey},
+    {"ik_key", E_Message_IKey},
 };
 
 #define KEYWORD_SIZE 256

--- a/src/milenage.c
+++ b/src/milenage.c
@@ -156,8 +156,6 @@ void f2345(uint8_t k[16], uint8_t rand[16],
 
     for (i=0; i<16; i++)
         ik[i] = out[i];
-
-    return;
 } /* end of function f2345 */
 
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -1577,7 +1577,13 @@ void scenario::parseAction(CActions *actions)
             tmpAction->setMessage(xp_get_string("host", actionElem), 0);
             tmpAction->setMessage(xp_get_string("port", actionElem), 1);
             tmpAction->setMessage(xp_get_string("protocol", actionElem), 2);
-            tmpAction->setActionType(CAction::E_AT_SET_DEST);
+			const char *_ptr = xp_get_value("local_port");
+			if (_ptr) {
+				tmpAction->setMessage(xp_get_string("local_port", actionElem), 3);
+				tmpAction->setActionType(CAction::E_AT_SET_DEST_W_SPORT);
+			} else {
+				tmpAction->setActionType(CAction::E_AT_SET_DEST);
+			}
         } else if(!strcmp(actionElem, "closecon")) {
             tmpAction->setActionType(CAction::E_AT_CLOSE_CON);
         } else if(!strcmp(actionElem, "strcmp")) {

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -101,7 +101,7 @@ int gai_getsockaddr(struct sockaddr_storage* ss, const char* host,
     }
 }
 
-void sockaddr_update_port(struct sockaddr_storage* ss, short port)
+void sockaddr_update_port(struct sockaddr_storage* ss, unsigned short port)
 {
     switch (ss->ss_family) {
     case AF_INET:
@@ -1241,7 +1241,7 @@ void process_message(SIPpSocket *socket, char *msg, ssize_t msg_size, struct soc
 }
 
 SIPpSocket::SIPpSocket(bool use_ipv6, int transport, int fd, int accepting):
-    ss_count(1),
+    ss_count(0),
     ss_ipv6(use_ipv6),
     ss_transport(transport),
     ss_control(false),


### PR DESCRIPTION
I was created additional program, which is used to calculate integrity and cyperhing keys before [authentication ...] field will be parsed and auth data will be calculated, so ipsec transport can be configured before sending of new message over encrypted channel. Additionally, I was added support of changing source port on `setdest` action. Some other minor changes (like adding some info into sipp.dtd) implemented too