### PR TITLE
CMake: Increase minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 
 # set the project name
 project(SIPp)


### PR DESCRIPTION
CMake is about to drop support for earlier versions.