### PR TITLE
Add 'global' option to 'optional' field in sipp.dtd

### DIFF
--- a/sipp.dtd
+++ b/sipp.dtd
@@ -27,7 +27,7 @@
 <!ATTLIST recv %messageCmdCommon; >
 <!ATTLIST recv response NMTOKEN #IMPLIED >
 <!ATTLIST recv request CDATA #IMPLIED >
-<!ATTLIST recv optional (true|false) #IMPLIED >
+<!ATTLIST recv optional (true|global|false) #IMPLIED >
 <!ATTLIST recv ignosesdp (true|false) #IMPLIED >
 <!ATTLIST recv rrs (true|false) #IMPLIED >
 <!ATTLIST recv auth (true|false) #IMPLIED >


### PR DESCRIPTION
Missing the 'global' option for 'optional' on sipp.dtd file.