### PR TITLE
Allow enabling of TLS verification without supplying CRL file

### DIFF
--- a/src/sslsocket.cpp
+++ b/src/sslsocket.cpp
@@ -296,11 +296,11 @@ enum tls_init_status TLS_init_context(void)
         return TLS_INIT_ERROR;
     }
 
-    bool gotCAFile = strlen(tls_ca_name) != 0;
-    bool gotCRLFile = strlen(tls_crl_name) != 0;
+    bool got_ca_file = strlen(tls_ca_name) != 0;
+    bool got_crl_file = strlen(tls_crl_name) != 0;
 
     /* Load the trusted CA's */
-    if (gotCAFile) {
+    if (got_ca_file) {
         SSL_CTX_load_verify_locations(sip_trp_ssl_ctx, tls_ca_name, NULL);
         SSL_CTX_load_verify_locations(sip_trp_ssl_ctx_client, tls_ca_name, NULL);
     }
@@ -308,8 +308,8 @@ enum tls_init_status TLS_init_context(void)
     /* TLS Verification only makes sense if an CA is specified or
      * we require CRL validation. */
     
-    if (gotCAFile || gotCRLFile) {
-        if (gotCRLFile) {
+    if (got_ca_file || got_crl_file) {
+        if (got_crl_file) {
             if (sip_tls_load_crls(sip_trp_ssl_ctx, tls_crl_name) == -1) {
                 ERROR("TLS_init_context: Unable to load CRL file (%s)", tls_crl_name);
                 return TLS_INIT_ERROR;

--- a/src/sslsocket.cpp
+++ b/src/sslsocket.cpp
@@ -290,24 +290,30 @@ enum tls_init_status TLS_init_context(void)
         return TLS_INIT_ERROR;
     }
 
+    bool gotCAFile = strlen(tls_ca_name) != 0;
+    bool gotCRLFile = strlen(tls_crl_name) != 0;
+
     /* Load the trusted CA's */
-    if (strlen(tls_ca_name) != 0) {
+    if (gotCAFile) {
         SSL_CTX_load_verify_locations(sip_trp_ssl_ctx, tls_ca_name, NULL);
         SSL_CTX_load_verify_locations(sip_trp_ssl_ctx_client, tls_ca_name, NULL);
     }
 
     /* TLS Verification only makes sense if an CA is specified or
      * we require CRL validation. */
-    if (strlen(tls_ca_name) != 0 || strlen(tls_crl_name) != 0) {
-        if (sip_tls_load_crls(sip_trp_ssl_ctx, tls_crl_name) == -1) {
-            ERROR("TLS_init_context: Unable to load CRL file (%s)", tls_crl_name);
-            return TLS_INIT_ERROR;
-        }
+    
+    if (gotCAFile || gotCRLFile) {
+        if (gotCRLFile) {
+            if (sip_tls_load_crls(sip_trp_ssl_ctx, tls_crl_name) == -1) {
+                ERROR("TLS_init_context: Unable to load CRL file (%s)", tls_crl_name);
+                return TLS_INIT_ERROR;
+            }
 
-        if (sip_tls_load_crls(sip_trp_ssl_ctx_client, tls_crl_name) == -1) {
-            ERROR("TLS_init_context: Unable to load CRL (client) file (%s)",
-                  tls_crl_name);
-            return TLS_INIT_ERROR;
+            if (sip_tls_load_crls(sip_trp_ssl_ctx_client, tls_crl_name) == -1) {
+                ERROR("TLS_init_context: Unable to load CRL (client) file (%s)",
+                    tls_crl_name);
+                return TLS_INIT_ERROR;
+            }
         }
         /* The following call forces to process the certificates with
          * the initialised SSL_CTX */


### PR DESCRIPTION
Currently CRL file specified via `tls_crl_name` flag is being loaded even if it wasn't supplied, causing TLS initialisation to fail:

```
    if (strlen(tls_ca_name) != 0 || strlen(tls_crl_name) != 0) {
        if (sip_tls_load_crls(sip_trp_ssl_ctx, tls_crl_name) == -1) {
```

This PR ensures that custom behaviour caused by `SSL_VERIFY_PEER` can be enabled without supplying CRL file.