### PR TITLE
Remove fprintf causing log spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Bugs fixed in 3.7.2
+===================
+
+- Remove excessive log
+
 Bugs fixed in 3.7.1
 =======================
 

--- a/src/prepare_pcap.c
+++ b/src/prepare_pcap.c
@@ -282,7 +282,6 @@ int prepare_pkts(const char* file, pcap_pkts* pkts)
     pkts->max = pkts->pkts + n_pkts;
     pkts->max_length = max_length;
     pkts->base = base;
-    fprintf(stderr, "In pcap %s, npkts %d\nmax pkt length %lu\nbase port %d\n", file, n_pkts, max_length, base);
     pcap_close(pcap);
 
     return 0;


### PR DESCRIPTION
Since https://github.com/SIPp/sipp/pull/521, prepare_pkts may be called on every call, not just on startup. This means that the log it prints to stderr is very visible and may cause performance problems. This commit removes it.