### PR TITLE
Do not accept bind_to_device at all if not supported

### DIFF
--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -322,7 +322,9 @@ MAYBE_EXTERN const char       * tls_crl_name            DEFVAL(DEFAULT_TLS_CRL);
 MAYBE_EXTERN double             tls_version             DEFVAL(0.0);
 #endif
 
+#ifdef SO_BINDTODEVICE
 MAYBE_EXTERN const char       * bind_to_device_name     DEFVAL(NULL);
+#endif
 
 MAYBE_EXTERN char*              scenario_file           DEFVAL(NULL);
 MAYBE_EXTERN char*              scenario_path           DEFVAL(NULL);

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -88,8 +88,10 @@ public:
     // Have we read a message from this socket?
     bool message_ready() { return ss_msglen > 0; };
 
+#ifdef SO_BINDTODEVICE
     // Bind to specific network device.
     int bind_to_device(const char* device_name);
+#endif
 
     static void pollset_process(int wait);
 

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -167,7 +167,9 @@ struct sipp_option options_table[] = {
     {"i", "Set the local IP address for 'Contact:','Via:', and 'From:' headers. Default is primary host IP address.\n", SIPP_OPTION_IP, local_ip, 1},
     {"p", "Set the local port number.  Default is a random free port chosen by the system.", SIPP_OPTION_INT, &user_port, 1},
     {"bind_local", "Bind socket to local IP address, i.e. the local IP address is used as the source IP address.  If SIPp runs in server mode it will only listen on the local IP address instead of all IP addresses.", SIPP_OPTION_SETFLAG, &bind_local, 1},
+#ifdef SO_BINDTODEVICE
     {"bind_to_device", "Bind socket to the specified network device. Requires superuser permissions.", SIPP_OPTION_STRING, &bind_to_device_name, 1},
+#endif
     {"ci", "Set the local control IP address", SIPP_OPTION_IP, control_ip, 1},
     {"cp", "Set the local control port number. Default is 8888.", SIPP_OPTION_INT, &control_port, 1},
     {"max_socket", "Set the max number of sockets to open simultaneously. This option is significant if you use one socket per call. Once this limit is reached, traffic is distributed over the sockets already opened. Default value is 50000", SIPP_OPTION_MAX_SOCKET, NULL, 1},

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1651,17 +1651,15 @@ int SIPpSocket::reconnect()
     return connect();
 }
 
-int SIPpSocket::bind_to_device(const char* device_name) {
 #ifdef SO_BINDTODEVICE
+int SIPpSocket::bind_to_device(const char* device_name) {
     if (setsockopt(this->ss_fd, SOL_SOCKET, SO_BINDTODEVICE,
                    device_name, strlen(device_name)) == -1) {
         ERROR_NO("setsockopt(SO_BINDTODEVICE) failed");
     }
     return 0;
-#else
-    ERROR("bind to device not supported on this platform.");
-#endif
 }
+#endif
 
 
 /*************************** I/O functions ***************************/
@@ -2483,10 +2481,12 @@ int open_connections()
 
     sipp_customize_socket(main_socket);
 
+#ifdef SO_BINDTODEVICE
     /* Bind to the device if any. */
     if (bind_to_device_name) {
         main_socket->bind_to_device(bind_to_device_name);
     }
+#endif
 
     /* Trying to bind local port */
     char peripaddr[256];


### PR DESCRIPTION
Better than running and quitting later.