### PR TITLE
Remove support for variable PCAP filenames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,13 @@
+BREAKING(!) changes in 3.7.3
+============================
+
+- Remove support for variables in PCAP filenames, originally introduced in 3.7.0~rc1.  See #673
+    
 Bugs fixed in 3.7.3
 ===================
 
 - Recovered `-mp` and `[auto_media_port]` to maintain backwards compatibility. (by Orgad Shaneh)
+- Fix crash when using PCAP play with more than one call (by Pete O'Neill)
 
 Bugs fixed in 3.7.2
 ===================

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -6077,12 +6077,6 @@ call::T_ActionResult call::executeAction(const char* msg, message* curmsg)
                    (currentAction->getActionType() == CAction::E_AT_PLAY_DTMF)) {
             play_args_t* play_args = 0;
             if ((currentAction->getActionType() == CAction::E_AT_PLAY_PCAP_AUDIO) ||
-                (currentAction->getActionType() == CAction::E_AT_PLAY_PCAP_IMAGE) ||
-                (currentAction->getActionType() == CAction::E_AT_PLAY_PCAP_VIDEO)) {
-                const char *fileName = createSendingMessage(currentAction->getMessage());
-                currentAction->setPcapArgs(fileName);
-            }
-            if ((currentAction->getActionType() == CAction::E_AT_PLAY_PCAP_AUDIO) ||
                 (currentAction->getActionType() == CAction::E_AT_PLAY_DTMF)) {
                 play_args = &(this->play_args_a);
             } else if (currentAction->getActionType() == CAction::E_AT_PLAY_PCAP_IMAGE) {


### PR DESCRIPTION
Fixes issues #576, #610, #673

The original variable PCAP filenames PR #521 would free and rewrite a single per-scenario-action block of memory for every call, but all calls would continue referencing the memory.  This led to various use-after-free issues.  The PCAP play design also isn't set up for loading a file per call, so the solution didn't scale well.

This PR removes the variable PCAP filenames feature, while retaining the variable RTPStream filenames feature, which doesn't have the same issues.

Specific testing done:
- that PCAP play is fixed
- that RTPStream continues to work, with files specified as any of:
  - `<exec rtp_stream="my_audio.wav"/>`
  - `<exec rtp_stream="[field0]"/>`
  - `<exec rtp_stream="[command_line_key]"/>`