### PR TITLE
Avoid GNU-specific xargs flags in regress/runtests

### DIFF
--- a/regress/runtests
+++ b/regress/runtests
@@ -6,7 +6,7 @@
 cd `dirname "$0"`
 
 # Cleanup test remnants.
-find . -name '*.log' | xargs --no-run-if-empty -d\\n rm -v
+find . -name '*.log' -print -delete
 echo
 
 # Export custom location SIPP binary if supplied.


### PR DESCRIPTION
In fact, avoid `xargs` entirely by using features built into `find` instead.