### PR TITLE
Logger: Append newlines to messages in error log files

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -464,7 +464,7 @@ static void _screen_error(int fatal, bool use_errno, int error, const char *fmt,
     }
 
     if (error_lfi.fptr) {
-        count += fprintf(error_lfi.fptr, "%s", screen_last_error);
+        count += fprintf(error_lfi.fptr, "%s\n", screen_last_error);
         fflush(error_lfi.fptr);
         if (ringbuffer_size && count > ringbuffer_size) {
             rotate_errorf();


### PR DESCRIPTION
Since 493e8f524d (Consistently use no LF in ERROR() calls) there are no newlines in the messages, so they should be appended centrally.

Fixes #722.