### PR TITLE
Fix issue where next_url could return garbage

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -5459,6 +5459,8 @@ bool call::process_incoming(const char* msg, const struct sockaddr_storage* src)
         realloc_ptr = (char*)realloc(next_req_url, MAX_HEADER_LEN);
         if (realloc_ptr) {
             next_req_url = realloc_ptr;
+            /* Ensure next_req_url has an empty value in case contact is missing */
+            next_req_url[0] = '\0';
         } else {
             free(next_req_url);
             ERROR("Out of memory!");


### PR DESCRIPTION
next_req_url, which is a zero terminated string, is not initialized when initially allocated.  Later code correctly zero terminates this string 99% of the time but fails to do so if there are no Record-Route or Contact headers.  Subsequent use of [next_url] will return garbage, best case. 