### PR TITLE
sipp.cpp:  Restore help for the -mp option

### DIFF
--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -281,7 +281,7 @@ struct sipp_option options_table[] = {
     {"mb", "Set the RTP echo buffer size (default: 2048).", SIPP_OPTION_INT, &media_bufsize, 1},
     {"min_rtp_port", "Minimum port number for RTP socket range.", SIPP_OPTION_INT, &min_rtp_port, 1},
     {"max_rtp_port", "Maximum port number for RTP socket range.", SIPP_OPTION_INT, &max_rtp_port, 1},
-    {"mp", nullptr, SIPP_OPTION_INT, &min_rtp_port, 1},
+    {"mp", "Sets -min_rtp_port for backwards compatibility.", SIPP_OPTION_INT, &min_rtp_port, 1},
     {"rtp_payload", "RTP default payload type.", SIPP_OPTION_INT, &rtp_default_payload, 1},
     {"rtp_threadtasks", "RTP number of playback tasks per thread.", SIPP_OPTION_INT, &rtp_tasks_per_thread, 1},
     {"rtp_buffsize", "Set the rtp socket send/receive buffer size.", SIPP_OPTION_INT, &rtp_buffsize, 1},


### PR DESCRIPTION
Set help text for the `-mp` option to...
"Sets -min_rtp_port for backwards compatibility."

Fixes: #730
