### PR TITLE
Initialize srand with hostname and PID

### DIFF
--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -493,6 +493,7 @@ void connect_local_twin_socket(char *);
 void close_peer_sockets();
 void close_local_sockets();
 void free_peer_addr_map();
+void randomseed();
 
 /********************* Reset global kludge  *******************/
 


### PR DESCRIPTION
We're running SIPp in a container scaleset, and ran into an issue where two instances started in the same second and continually picked the same random numbers as each other, which meant that `InputFileRandomOrder` actually had the instances continually 'randomly' picking the same entries.

To avoid this, this change adds a bit more noise to the start-of-day call to `srand()`, mixing in the PID and the hostname, which would avoid two instances using the same seed.

I'd welcome an alternative and better way to do this!