### PR TITLE
Fix out-of-bound read for invalid XML

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -130,7 +130,9 @@ static char* quoted_strchr(const char* s, int c)
     for (p = s; *p && *p != c; p++) {
         if (*p == '"') {
             p++;
-            p += strcspn(p, "\"");
+            p += strcspn(p, "\"\n");
+            if (!*p)
+                break;
         }
     }
 


### PR DESCRIPTION
In the given example, there is an invalid field:
```
To: sut <sip:[service]@[remote_ip]:"remote_port]>
```
There are no more quotes later. When we search for the terminating quote, nothing is found, so we skip to the end of the string. Then the loop continues, we have p++ and continue beyond the buffer.

Fixes #727.