### PR TITLE
Include the SNI for SSL client

### DIFF
--- a/src/sslsocket.cpp
+++ b/src/sslsocket.cpp
@@ -126,7 +126,16 @@ const char *SSL_error_string(int ssl_error, int orig_ret)
 
 SSL* SSL_new_client()
 {
-    return SSL_new(sip_trp_ssl_ctx_client);
+    SSL* ssl = SSL_new(sip_trp_ssl_ctx_client);
+
+    // Inject the ServerNameIndication (SNI).
+    // It requires to be a hostname. However, SSL takes whatever we set.
+    // Ref https://datatracker.ietf.org/doc/html/rfc6066#section-3
+    if (strcmp(remote_ip, remote_host)) {
+        SSL_set_tlsext_host_name(ssl, remote_host);
+    }
+
+    return ssl;
 }
 
 SSL* SSL_new_server()


### PR DESCRIPTION
Add SNI for SSL client only.
As SSL related function applies any input into the SNI extension, a minimal validation was added to ignore IP endpoint.

From wireshark, the TLS handshake has visible differences
![image](https://github.com/user-attachments/assets/f5a4645e-eb2c-4289-b7ac-1433f81ba155)
- The 1st clientHello is the result of the command `sipp -t l1 -sn uac <server_as_hostname>:5061`
- The 2nd clientHello is the result of the command `sipp -t l1 -sn uac <server_as_direct_ip>:5061`

fixes #753