### PR TITLE
Introduce Debian-based Dockerfile

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -42,9 +42,7 @@ jobs:
 
 
   build-static:
-
     runs-on: ubuntu-24.04
-
     steps:
     - uses: actions/checkout@v4
     - name: prepare
@@ -55,3 +53,12 @@ jobs:
       with:
          name: sipp
          path: ./sipp
+
+  build-wolfssl:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: prepare
+      run: git submodule update --init
+    - name: build-wolfssl
+      run: docker build -f docker/Dockerfile.debian --build-arg WOLFSSL=1 .

--- a/README.md
+++ b/README.md
@@ -69,8 +69,24 @@ docker build -t sipp -f docker/Dockerfile --output=. --target=bin .
 ```
 
 Special arguments can be passed with `--build-arg`:
-* `FULL=1` - build all optional components
-* `DEBUG=1` - build with debug symbols
+* `FULL=1` - build all optional components.
+* `DEBUG=1` - build with debug symbols.
+
+## Debian-based docker build
+
+SIPp can be built in a Debian-based docker container. Unlike the Alpine
+build, this build is not static, and it supports wolfSSL.
+
+To build a Debian-based docker container, run:
+```
+git submodule update --init
+docker build -t sipp -f docker/Dockerfile.debian .
+```
+
+Special arguments can be passed with `--build-arg`:
+* `FULL=1` - build all optional components, including OpenSSL.
+* `WOLFSSL=1` - build with wolfSSL (only works without FULL).
+* `DEBUG=1` - build with debug symbols.
 
 # Support
 

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,0 +1,54 @@
+# Usage (from within the git repo):
+#   git submodule update --init
+#   docker build -t sipp -f docker/Dockerfile.debian .
+
+FROM debian:12-slim AS build
+
+ARG FULL=''
+ARG WOLFSSL=''
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  binutils \
+  cmake \
+  g++ \
+  gcc \
+  git \
+  libgsl-dev \
+  libpcap-dev \
+  libncurses-dev \
+  make \
+  ninja-build \
+  ${WOLFSSL:+libwolfssl-dev} \
+  ${FULL:+libsctp-dev libssl-dev}
+
+WORKDIR /sipp
+COPY CMakeLists.txt ./
+COPY src src
+COPY include include
+COPY gtest gtest
+
+ARG DEBUG=''
+RUN --mount=type=bind,target=.git,source=.git \
+  git config --global --add safe.directory /sipp && \
+  cmake . -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DUSE_PCAP=1 \
+    -DUSE_GSL=1 \
+    ${DEBUG:+-DDEBUG=1} \
+    ${FULL:+-DUSE_SSL=1 -DUSE_SCTP=1} \
+  && ninja
+
+FROM debian:12-slim
+CMD ["sipp"]
+ARG FULL=''
+ARG WOLFSSL=''
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl27 \
+  libpcap0.8 \
+  libncursesw6 \
+  ${WOLFSSL:+libwolfssl35} \
+  ${FULL:+libsctp1 libssl3} \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=build /sipp/sipp /usr/local/bin/sipp


### PR DESCRIPTION
Can be useful for building with wolfSSL, and for testing different platforms.

Use it in CI to test wolfSSL.