### PR TITLE
Make <nop> override the call::last_action_result only if it is a failure

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -1897,7 +1897,11 @@ bool call::executeMessage(message *curmsg)
         callDebug("Executing NOP at index %d.\n", curmsg->index);
         do_bookkeeping(curmsg);
         actionResult = executeAction(nullptr, curmsg);
-        last_action_result = actionResult;
+        if (actionResult != call::E_AR_NO_ERROR) {
+            // Store last action result if it is an error
+            // and go on with the scenario
+            call::last_action_result = actionResult;
+        }
         if (actionResult == E_AR_RTPECHO_ERROR)
         {
             terminate(CStat::E_CALL_FAILED);


### PR DESCRIPTION
Otherwise it clears the failure flag from the call even if a previous action failed.