### PR TITLE
Set null terminator after realloc

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -1986,6 +1986,7 @@ bool call::executeMessage(message *curmsg)
         last_send_index = curmsg->index;
         last_send_len = msgLen;
         realloc_ptr = (char *) realloc(last_send_msg, msgLen+1);
+        realloc_ptr[msgLen] = '\0';
         if (realloc_ptr) {
             last_send_msg = realloc_ptr;
         } else {


### PR DESCRIPTION
When we `realloc` for a smaller message than previous, it sometimes detects old SIPp records from old messages making the record malformed. For example, `call-id` parsing gets malformed in new smaller message because it matches 2 lines, due to missing null terminator.

TO-DO: fix all `realloc` instances