### PR TITLE
Support RFC3339 timestamp format

### DIFF
--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -214,6 +214,7 @@ MAYBE_EXTERN const char       * auth_username           DEFVAL(0);
 MAYBE_EXTERN unsigned long      report_freq             DEFVAL(DEFAULT_REPORT_FREQ);
 MAYBE_EXTERN unsigned long      report_freq_dumpLog     DEFVAL
 (DEFAULT_REPORT_FREQ_DUMP_LOG);
+MAYBE_EXTERN bool               rfc3339                 DEFVAL(false);
 MAYBE_EXTERN bool               periodic_rtd            DEFVAL(false);
 MAYBE_EXTERN const char       * stat_delimiter          DEFVAL(";");
 

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -2613,6 +2613,9 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
     for (int i = 0; i < src->numComponents(); i++) {
         MessageComponent *comp = src->getComponent(i);
         int left = buf_len - (dest - msg_buffer);
+        if (left <= 0) {
+            break;
+        }
         switch(comp->type) {
         case E_Message_Literal:
             if (suppresscrlf) {

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -1148,7 +1148,7 @@ int call::_callDebug(const char *fmt, ...)
 
     struct timeval now;
     gettimeofday(&now, nullptr);
-    debugLength += snprintf(debugBuffer + debugLength, TIME_LENGTH + 2, "%s ", CStat::formatTime(&now));
+    debugLength += snprintf(debugBuffer + debugLength, TIME_LENGTH + 2, "%s ", CStat::formatTime(&now, rfc3339));
 
     va_start(ap, fmt);
     debugLength += vsnprintf(debugBuffer + debugLength, ret + 1, fmt, ap);
@@ -3829,7 +3829,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
         case E_Message_Timestamp:
             struct timeval currentTime;
             gettimeofday(&currentTime, nullptr);
-            dest += snprintf(dest, left, "%s", CStat::formatTime(&currentTime));
+            dest += snprintf(dest, left, "%s", CStat::formatTime(&currentTime, rfc3339));
             break;
         case E_Message_Date:
             char buf[256];

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -74,7 +74,7 @@ void print_count_file(FILE* f, int header)
         main_scenario->stats->getStartTime(&startTime);
         unsigned long globalElapsedTime =
             CStat::computeDiffTimeInMs(&currentTime, &startTime);
-        fprintf(f, "%s%s", CStat::formatTime(&currentTime), stat_delimiter);
+        fprintf(f, "%s%s", CStat::formatTime(&currentTime, rfc3339), stat_delimiter);
         fprintf(f, "%s%s", CStat::msToHHMMSSus(globalElapsedTime),
                 stat_delimiter);
     }
@@ -200,7 +200,7 @@ void print_error_codes_file(FILE* f)
     main_scenario->stats->getStartTime(&startTime);
     unsigned long globalElapsedTime =
         CStat::computeDiffTimeInMs(&currentTime, &startTime);
-    fprintf(f, "%s%s", CStat::formatTime(&currentTime), stat_delimiter);
+    fprintf(f, "%s%s", CStat::formatTime(&currentTime, rfc3339), stat_delimiter);
     fprintf(f, "%s%s", CStat::msToHHMMSSus(globalElapsedTime), stat_delimiter);
 
     // Print comma-separated list of all error codes seen since the last time
@@ -440,7 +440,7 @@ static void _screen_error(int fatal, bool use_errno, int error, const char *fmt,
     const std::size_t bufSize = sizeof(screen_last_error) / sizeof(screen_last_error[0]);
     const char* const bufEnd = &screen_last_error[bufSize];
     char* c = screen_last_error;
-    _advance(c, snprintf(c, bufEnd - c, "%s: ", CStat::formatTime(&currentTime)));
+    _advance(c, snprintf(c, bufEnd - c, "%s: ", CStat::formatTime(&currentTime, rfc3339)));
     if (c < bufEnd) {
         _advance(c, vsnprintf(c, bufEnd - c, fmt, ap));
     }

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -364,6 +364,7 @@ struct sipp_option options_table[] = {
     {"stat_delimiter", "Set the delimiter for the statistics file", SIPP_OPTION_STRING, &stat_delimiter, 1},
     {"stf", "Set the file name to use to dump statistics", SIPP_OPTION_ARGI, &argiFileName, 1},
     {"fd", "Set the statistics dump log report frequency. Default is 60 and default unit is seconds.", SIPP_OPTION_TIME_SEC, &report_freq_dumpLog, 1},
+    {"rfc3339", "Use timestamps in RFC3339 format.", SIPP_OPTION_SETFLAG, &rfc3339, 1},
     {"periodic_rtd", "Reset response time partition counters each logging interval.", SIPP_OPTION_SETFLAG, &periodic_rtd, 1},
 
     {"trace_msg", "Displays sent and received SIP messages in <scenario file name>_<pid>_messages.log", SIPP_OPTION_SETFLAG, &useMessagef, 1},
@@ -1080,7 +1081,7 @@ static void manage_oversized_file(int signum)
     fprintf(f,
             "-------------------------------------------- %s\n"
             "Max file size reached - no more logs\n",
-            CStat::formatTime(&currentTime));
+            CStat::formatTime(&currentTime, rfc3339));
 
     fclose(f);
     stop_all_traces();

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2206,7 +2206,7 @@ int SIPpSocket::write(const char *buffer, ssize_t len, int flags, struct sockadd
             char *msg = strdup(buffer);
             const char *call_id = get_trimmed_call_id(msg);
             TRACE_SHORTMSG("%s\tS\t%s\tCSeq:%s\t%s\n",
-                           CStat::formatTime(&currentTime), call_id, get_header_content(msg, "CSeq:"), get_first_line(msg));
+                           CStat::formatTime(&currentTime, rfc3339), call_id, get_header_content(msg, "CSeq:"), get_first_line(msg));
             free(msg);
         }
 

--- a/src/stat.cpp
+++ b/src/stat.cpp
@@ -1262,9 +1262,9 @@ void CStat::dumpData ()
     }
 
     // content
-    (*M_outputStream) << formatTime(&M_startTime)               << stat_delimiter;
-    (*M_outputStream) << formatTime(&M_plStartTime)             << stat_delimiter;
-    (*M_outputStream) << formatTime(&currentTime)               << stat_delimiter
+    (*M_outputStream) << formatTime(&M_startTime, rfc3339)      << stat_delimiter;
+    (*M_outputStream) << formatTime(&M_plStartTime, rfc3339)    << stat_delimiter;
+    (*M_outputStream) << formatTime(&currentTime, rfc3339)      << stat_delimiter
                       << msToHHMMSS(localElapsedTime)           << stat_delimiter;
     (*M_outputStream) << msToHHMMSS(globalElapsedTime)          << stat_delimiter;
     if (users >= 0) {
@@ -1459,7 +1459,7 @@ char* CStat::formatTime (struct timeval* P_tv, bool with_epoch)
         memset (L_time, 0, TIME_LENGTH);
     } else {
         if (with_epoch) {
-            sprintf(L_time, "%4.4d-%2.2d-%2.2d %2.2d:%2.2d:%2.2d.%06ld",
+            sprintf(L_time, "%4.4d-%2.2d-%2.2dT%2.2d:%2.2d:%2.2d.%06ld",
                     L_currentDate->tm_year + 1900,
                     L_currentDate->tm_mon + 1,
                     L_currentDate->tm_mday,


### PR DESCRIPTION
New CLI option suggestion:  
```
-rfc3339         : Use timestamps in RFC3339 format.
```

I believe this option of timestamp format compliance helps in parsing SIPp traces and logs by monitoring tools.  

 