### PR TITLE
docs: update actions.rst by adding support for nop command

### DIFF
--- a/docs/scenarios/actions.rst
+++ b/docs/scenarios/actions.rst
@@ -1,12 +1,12 @@
 Actions
 =======
 
-In a `recv` or `recvCmd` command, you have the possibility to execute
+In a `recv`, `recvCmd` or `nop` command, you have the possibility to execute
 an action. Several actions are available:
 
 
 + `Regular expressions`_ (ereg)
-+ Log something in aa log file (log)
++ Log something in a log file (log)
 + Execute an external (system), internal (int_cmd) or
   pcap_play_audio/pcap_play_video command (exec)
 + Manipulate double precision variables using arithmetic


### PR DESCRIPTION
This pull request updates the documentation in `docs/scenarios/actions.rst` to improve clarity and accuracy. The most notable changes include adding the `nop` command to the list of commands that can execute actions and fixing a typo in the description of the `log` action.

Documentation improvements:

* Added `nop` to the list of commands capable of executing actions, alongside `recv` and `recvCmd`, to ensure completeness.
* Corrected a typographical error in the description of the `log` action by fixing "aa log file" to "a log file."