### PR TITLE
Fix RTPCHECK functionality regressions

### DIFF
--- a/include/call.hpp
+++ b/include/call.hpp
@@ -33,7 +33,7 @@
 #include "send_packets.h"
 #endif
 #include "rtpstream.hpp"
-#include "jlsrtp.hpp"
+#include "srtp_channel.hpp"
 
 #include <stdarg.h>
 
@@ -188,14 +188,14 @@ protected:
 #endif
 
     rtpstream_callinfo_t rtpstream_callinfo;
-    JLSRTP _txUACAudio;
-    JLSRTP _rxUACAudio;
-    JLSRTP _txUASAudio;
-    JLSRTP _rxUASAudio;
-    JLSRTP _txUACVideo;
-    JLSRTP _rxUACVideo;
-    JLSRTP _txUASVideo;
-    JLSRTP _rxUASVideo;
+    SrtpChannel _txUACAudio;
+    SrtpChannel _rxUACAudio;
+    SrtpChannel _txUASAudio;
+    SrtpChannel _rxUASAudio;
+    SrtpChannel _txUACVideo;
+    SrtpChannel _rxUACVideo;
+    SrtpChannel _txUASVideo;
+    SrtpChannel _rxUASVideo;
 #ifdef USE_TLS
     char _pref_audio_cs_out[25];
     char _pref_video_cs_out[25];

--- a/include/jlsrtp.hpp
+++ b/include/jlsrtp.hpp
@@ -32,12 +32,13 @@
 #include <wolfssl/openssl/hmac.h>
 #endif
 
+#include <string>
+
 #if defined(USE_OPENSSL) || defined(USE_WOLFSSL)
 
-#include <string>
 #include <vector>
 
-#define JLSRTP_VERSION              0.5
+#define JLSRTP_VERSION              0.6
 #define JLSRTP_ENCRYPTION_KEY_LENGTH        16  // bytes
 #define JLSRTP_SALTING_KEY_LENGTH           14  // bytes
 #define JLSRTP_AUTHENTICATION_KEY_LENGTH    20  // bytes
@@ -1164,7 +1165,7 @@ class JLSRTP
          * @param[in]       ipAddress   IP address
          * @param[in]       port        Port
          */
-        JLSRTP(unsigned int ssrc, std::string ipAddress, unsigned short port);
+        JLSRTP(unsigned int ssrc, const std::string& ipAddress, unsigned short port);
 
         /**
          * ~JLSRTP
@@ -1187,6 +1188,17 @@ class JLSRTP
          * Default constructor
          */
         JLSRTP();
+
+        /**
+         * JLSRTP
+         *
+         * Custom constructor
+         *
+         * @param[in]       ssrc        SSRC ID
+         * @param[in]       ipAddress   IP address
+         * @param[in]       port        Port
+         */
+        JLSRTP(unsigned int ssrc, const std::string& ipAddress, unsigned short port);
 
         /**
          * ~JLSRTP

--- a/include/jlsrtp.hpp
+++ b/include/jlsrtp.hpp
@@ -613,7 +613,7 @@ class JLSRTP
          *
          * Resets crypto context
          *
-         * @param[in]       sssrc       SSRC ID
+         * @param[in]       ssrc        SSRC ID
          * @param[in]       ipAddress   IP address
          * @param[in]       port        Port
          */
@@ -1160,7 +1160,7 @@ class JLSRTP
          *
          * Custom constructor
          *
-         * @param[in]       sssrc       SSRC ID
+         * @param[in]       ssrc        SSRC ID
          * @param[in]       ipAddress   IP address
          * @param[in]       port        Port
          */

--- a/include/rtpstream.hpp
+++ b/include/rtpstream.hpp
@@ -19,14 +19,14 @@
 #ifndef __RTPSTREAM__
 #define __RTPSTREAM__
 
-#include "jlsrtp.hpp"
-
 #include <unordered_map>
 
 #define RTPSTREAM_MAX_FILENAMELEN 256
 #define RTPSTREAM_MAX_PAYLOADNAME 256
 #define RTPECHO_MAX_FILENAMELEN 256
 #define RTPECHO_MAX_PAYLOADNAME 256
+
+class JLSRTP;
 
 #ifdef USE_TLS
 typedef struct _SrtpAudioInfoParams

--- a/include/srtp_channel.hpp
+++ b/include/srtp_channel.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "jlsrtp.hpp"
+
+#ifdef GLOBALS_FULL_DEFINITION
+#define MAYBE_EXTERN
+#define DEFVAL(value) = value
+#else
+#define MAYBE_EXTERN extern
+#define DEFVAL(value)
+#endif
+
+MAYBE_EXTERN unsigned int global_ssrc_id DEFVAL(0);
+
+class SrtpChannel : public JLSRTP
+{
+public:
+    SrtpChannel() : JLSRTP(global_ssrc_id, "127.0.0.1", 0) {}
+    SrtpChannel(const JLSRTP &base) : JLSRTP(base) {}
+    SrtpChannel &operator=(const JLSRTP &base)
+    {
+        JLSRTP::operator=(base);
+        return *this;
+    }
+};

--- a/sipp_scenarios/pfca_uas_both_crypto_simple.xml
+++ b/sipp_scenarios/pfca_uas_both_crypto_simple.xml
@@ -98,24 +98,17 @@
       a=fmtp:97 profile-level-id=42800d; max-mbps=108000; max-fs=3600; max-br=1280; packetization-mode=1
 
     ]]>
+
+    <action>
+        <exec rtp_echo="startaudio,0,PCMU/8000" />
+        <exec rtp_echo="startvideo,99,H264/90000" />
+        <exec rtp_echo="updateaudio,0,PCMU/8000" />
+        <exec rtp_echo="updatevideo,99,H264/90000" />
+    </action>
   </send>
 
   <recv request="ACK">
   </recv>
-
-  <nop>
-    <action>
-        <exec rtp_echo="startaudio,0,PCMU/8000" />
-        <exec rtp_echo="startvideo,99,H264/90000" />
-    </action>
-  </nop>
-
-  <nop>
-    <action>
-        <exec rtp_echo="updateaudio,0,PCMU/8000" />
-        <exec rtp_echo="updatevideo,99,H264/90000" />
-    </action>
-  </nop>
 
   <recv request="BYE">
   </recv>

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -414,19 +414,19 @@ int call::extract_srtp_remote_info(const char * msg, SrtpAudioInfoParams &pA, Sr
 
     pA.primary_audio_cryptotag = 0;
     pV.primary_video_cryptotag = 0;
-    memset(pA.primary_audio_cryptosuite, 0, sizeof(pA.primary_audio_cryptosuite));
-    memset(pV.primary_video_cryptosuite, 0, sizeof(pV.primary_video_cryptosuite));
-    memset(pA.primary_audio_cryptokeyparams, 0, sizeof(pA.primary_audio_cryptokeyparams));
-    memset(pV.primary_video_cryptokeyparams, 0, sizeof(pV.primary_video_cryptokeyparams));
+    *pA.primary_audio_cryptosuite = 0;
+    *pV.primary_video_cryptosuite = 0;
+    *pA.primary_audio_cryptokeyparams = 0;
+    *pV.primary_video_cryptokeyparams = 0;
     pA.primary_unencrypted_audio_srtp = false;
     pV.primary_unencrypted_video_srtp = false;
 
     pA.secondary_audio_cryptotag = 0;
     pV.secondary_video_cryptotag = 0;
-    memset(pA.secondary_audio_cryptosuite, 0, sizeof(pA.secondary_audio_cryptosuite));
-    memset(pV.secondary_video_cryptosuite, 0, sizeof(pV.secondary_video_cryptosuite));
-    memset(pA.secondary_audio_cryptokeyparams, 0, sizeof(pA.secondary_audio_cryptokeyparams));
-    memset(pV.secondary_video_cryptokeyparams, 0, sizeof(pV.secondary_video_cryptokeyparams));
+    *pA.secondary_audio_cryptosuite = 0;
+    *pV.secondary_video_cryptosuite = 0;
+    *pA.secondary_audio_cryptokeyparams = 0;
+    *pV.secondary_video_cryptokeyparams = 0;
     pA.secondary_unencrypted_audio_srtp = false;
     pV.secondary_unencrypted_video_srtp = false;
 
@@ -951,8 +951,8 @@ void call::init(scenario * call_scenario, SIPpSocket *socket, struct sockaddr_st
         }
     }
 
-    memset(_pref_audio_cs_out, 0, sizeof(_pref_audio_cs_out));
-    memset(_pref_video_cs_out, 0, sizeof(_pref_video_cs_out));
+    *_pref_audio_cs_out = 0;
+    *_pref_video_cs_out = 0;
 #endif // USE_TLS
     /* check and warn on rtpstream_new_call result? -> error alloc'ing mem */
     rtpstream_new_call(&rtpstream_callinfo);
@@ -2589,21 +2589,21 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
 
     pA.audio_found = false;
     pA.primary_audio_cryptotag = 0;
-    memset(pA.primary_audio_cryptosuite, 0, sizeof(pA.primary_audio_cryptosuite));
-    memset(pA.primary_audio_cryptokeyparams, 0, sizeof(pA.primary_audio_cryptokeyparams));
+    *pA.primary_audio_cryptosuite = 0;
+    *pA.primary_audio_cryptokeyparams = 0;
     pA.secondary_audio_cryptotag = 0;
-    memset(pA.secondary_audio_cryptosuite, 0, sizeof(pA.secondary_audio_cryptosuite));
-    memset(pA.secondary_audio_cryptokeyparams, 0, sizeof(pA.secondary_audio_cryptokeyparams));
+    *pA.secondary_audio_cryptosuite = 0;
+    *pA.secondary_audio_cryptokeyparams = 0;
     pA.primary_unencrypted_audio_srtp = false;
     pA.secondary_unencrypted_audio_srtp = false;
 
     pV.video_found = false;
     pV.primary_video_cryptotag = 0;
-    memset(pV.primary_video_cryptosuite, 0, sizeof(pV.primary_video_cryptosuite));
-    memset(pV.primary_video_cryptokeyparams, 0, sizeof(pV.primary_video_cryptokeyparams));
+    *pV.primary_video_cryptosuite = 0;
+    *pV.primary_video_cryptokeyparams = 0;
     pV.secondary_video_cryptotag = 0;
-    memset(pV.secondary_video_cryptosuite, 0, sizeof(pV.secondary_video_cryptosuite));
-    memset(pV.secondary_video_cryptokeyparams, 0, sizeof(pV.secondary_video_cryptokeyparams));
+    *pV.secondary_video_cryptosuite = 0;
+    *pV.secondary_video_cryptokeyparams = 0;
     pV.primary_unencrypted_video_srtp = false;
     pV.secondary_unencrypted_video_srtp = false;
 #endif // USE_TLS
@@ -2809,7 +2809,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             if ((getSessionStateCurrent() == eNoSession) || (getSessionStateCurrent() == eCompleted))
             {
                 logSrtpInfo("call::createSendingMessage():  Marking preferred OFFER cryptosuite...\n");
-                strncat(_pref_audio_cs_out, "AES_CM_128_HMAC_SHA1_80", sizeof(_pref_audio_cs_out) - 1);
+                strcpy(_pref_audio_cs_out, "AES_CM_128_HMAC_SHA1_80");
             }
             else if (getSessionStateCurrent() == eOfferReceived)
             {
@@ -2840,7 +2840,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
 
             pA.audio_found = true;
-            strncat(pA.primary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_80", sizeof(pA.primary_audio_cryptosuite) - 1);
+            strcpy(pA.primary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "AES_CM_128_HMAC_SHA1_80");
             srtp_audio_updated = true;
         }
@@ -2860,7 +2860,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
                 _txUASAudio.selectHashAlgorithm(HMAC_SHA1_80, SECONDARY_CRYPTO);
             }
             pA.audio_found = true;
-            strncat(pA.secondary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_80", sizeof(pA.secondary_audio_cryptosuite) - 1);
+            strcpy(pA.secondary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "AES_CM_128_HMAC_SHA1_80");
             srtp_audio_updated = true;
         }
@@ -2883,7 +2883,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             if ((getSessionStateCurrent() == eNoSession) || (getSessionStateCurrent() == eCompleted))
             {
                 logSrtpInfo("call::createSendingMessage():  Marking preferred OFFER cryptosuite...\n");
-                strncat(_pref_audio_cs_out, "AES_CM_128_HMAC_SHA1_32", sizeof(_pref_audio_cs_out) - 1);
+                strcpy(_pref_audio_cs_out, "AES_CM_128_HMAC_SHA1_32");
             }
             else if (getSessionStateCurrent() == eOfferReceived)
             {
@@ -2914,7 +2914,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
 
             pA.audio_found = true;
-            strncat(pA.primary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_32", sizeof(pA.primary_audio_cryptosuite) - 1);
+            strcpy(pA.primary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "AES_CM_128_HMAC_SHA1_32");
             srtp_audio_updated = true;
         }
@@ -2934,7 +2934,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
                 _txUASAudio.selectHashAlgorithm(HMAC_SHA1_32, SECONDARY_CRYPTO);
             }
             pA.audio_found = true;
-            strncat(pA.secondary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_32", sizeof(pA.secondary_audio_cryptosuite) - 1);
+            strcpy(pA.secondary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "AES_CM_128_HMAC_SHA1_32");
             srtp_audio_updated = true;
         }
@@ -2957,7 +2957,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             if ((getSessionStateCurrent() == eNoSession) || (getSessionStateCurrent() == eCompleted))
             {
                 logSrtpInfo("call::createSendingMessage():  Marking preferred OFFER cryptosuite...\n");
-                strncat(_pref_audio_cs_out, "NULL_HMAC_SHA1_80", sizeof(_pref_audio_cs_out) - 1);
+                strcpy(_pref_audio_cs_out, "NULL_HMAC_SHA1_80");
             }
             else if (getSessionStateCurrent() == eOfferReceived)
             {
@@ -2988,7 +2988,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
 
             pA.audio_found = true;
-            strncat(pA.primary_audio_cryptosuite, "NULL_HMAC_SHA1_80", sizeof(pA.primary_audio_cryptosuite) - 1);
+            strcpy(pA.primary_audio_cryptosuite, "NULL_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "NULL_HMAC_SHA1_80");
             srtp_audio_updated = true;
         }
@@ -3008,7 +3008,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
                 _txUASAudio.selectHashAlgorithm(HMAC_SHA1_80, SECONDARY_CRYPTO);
             }
             pA.audio_found = true;
-            strncat(pA.secondary_audio_cryptosuite, "NULL_HMAC_SHA1_80", sizeof(pA.secondary_audio_cryptosuite) - 1);
+            strcpy(pA.secondary_audio_cryptosuite, "NULL_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "NULL_HMAC_SHA1_80");
             srtp_audio_updated = true;
         }
@@ -3031,7 +3031,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             if ((getSessionStateCurrent() == eNoSession) || (getSessionStateCurrent() == eCompleted))
             {
                 logSrtpInfo("call::createSendingMessage():  Marking preferred OFFER cryptosuite...\n");
-                strncat(_pref_audio_cs_out, "NULL_HMAC_SHA1_32", sizeof(_pref_audio_cs_out) - 1);
+                strcpy(_pref_audio_cs_out, "NULL_HMAC_SHA1_32");
             }
             else if (getSessionStateCurrent() == eOfferReceived)
             {
@@ -3062,7 +3062,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
 
             pA.audio_found = true;
-            strncat(pA.primary_audio_cryptosuite, "NULL_HMAC_SHA1_32", sizeof(pA.primary_audio_cryptosuite) - 1);
+            strcpy(pA.primary_audio_cryptosuite, "NULL_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "NULL_HMAC_SHA1_32");
             srtp_audio_updated = true;
         }
@@ -3082,7 +3082,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
                 _txUASAudio.selectHashAlgorithm(HMAC_SHA1_32, SECONDARY_CRYPTO);
             }
             pA.audio_found = true;
-            strncat(pA.secondary_audio_cryptosuite, "NULL_HMAC_SHA1_32", sizeof(pA.secondary_audio_cryptosuite) - 1);
+            strcpy(pA.secondary_audio_cryptosuite, "NULL_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "NULL_HMAC_SHA1_32");
             srtp_audio_updated = true;
         }
@@ -3187,7 +3187,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
             pA.audio_found = true;
             pA.primary_unencrypted_audio_srtp = true;
-            strncat(pA.primary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_80", sizeof(pA.primary_audio_cryptosuite) - 1);
+            strcpy(pA.primary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "UNENCRYPTED_SRTP");
             srtp_audio_updated = true;
         }
@@ -3208,7 +3208,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
             pA.audio_found = true;
             pA.secondary_unencrypted_audio_srtp = true;
-            strncat(pA.secondary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_80", sizeof(pA.secondary_audio_cryptosuite) - 1);
+            strcpy(pA.secondary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "UNENCRYPTED_SRTP");
             srtp_audio_updated = true;
         }
@@ -3229,7 +3229,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
             pA.audio_found = true;
             pA.primary_unencrypted_audio_srtp = true;
-            strncat(pA.primary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_32", sizeof(pA.primary_audio_cryptosuite) - 1);
+            strcpy(pA.primary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "UNENCRYPTED_SRTP");
             srtp_audio_updated = true;
         }
@@ -3250,7 +3250,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
             pA.audio_found = true;
             pA.secondary_unencrypted_audio_srtp = true;
-            strncat(pA.secondary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_32", sizeof(pA.secondary_audio_cryptosuite) - 1);
+            strcpy(pA.secondary_audio_cryptosuite, "AES_CM_128_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "UNENCRYPTED_SRTP");
             srtp_audio_updated = true;
         }
@@ -3309,7 +3309,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             if ((getSessionStateCurrent() == eNoSession) || (getSessionStateCurrent() == eCompleted))
             {
                 logSrtpInfo("call::createSendingMessage():  Marking preferred OFFER cryptosuite...\n");
-                strncat(_pref_video_cs_out, "AES_CM_128_HMAC_SHA1_80", sizeof(_pref_video_cs_out) - 1);
+                strcpy(_pref_video_cs_out, "AES_CM_128_HMAC_SHA1_80");
             }
             else if (getSessionStateCurrent() == eOfferReceived)
             {
@@ -3340,7 +3340,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
 
             pV.video_found = true;
-            strncat(pV.primary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_80", sizeof(pV.primary_video_cryptosuite) - 1);
+            strcpy(pV.primary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "AES_CM_128_HMAC_SHA1_80");
             srtp_video_updated = true;
         }
@@ -3360,7 +3360,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
                 _txUASVideo.selectHashAlgorithm(HMAC_SHA1_80, SECONDARY_CRYPTO);
             }
             pV.video_found = true;
-            strncat(pV.secondary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_80", sizeof(pV.secondary_video_cryptosuite) - 1);
+            strcpy(pV.secondary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "AES_CM_128_HMAC_SHA1_80");
             srtp_video_updated = true;
         }
@@ -3383,7 +3383,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             if ((getSessionStateCurrent() == eNoSession) || (getSessionStateCurrent() == eCompleted))
             {
                 logSrtpInfo("call::createSendingMessage():  Marking preferred OFFER cryptosuite...\n");
-                strncat(_pref_video_cs_out, "AES_CM_128_HMAC_SHA1_32", sizeof(_pref_video_cs_out) - 1);
+                strcpy(_pref_video_cs_out, "AES_CM_128_HMAC_SHA1_32");
             }
             else if (getSessionStateCurrent() == eOfferReceived)
             {
@@ -3414,7 +3414,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
 
             pV.video_found = true;
-            strncat(pV.primary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_32", sizeof(pV.primary_video_cryptosuite) - 1);
+            strcpy(pV.primary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "AES_CM_128_HMAC_SHA1_32");
             srtp_video_updated = true;
         }
@@ -3434,7 +3434,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
                 _txUASVideo.selectHashAlgorithm(HMAC_SHA1_32, SECONDARY_CRYPTO);
             }
             pV.video_found = true;
-            strncat(pV.secondary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_32", sizeof(pV.secondary_video_cryptosuite) - 1);
+            strcpy(pV.secondary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "AES_CM_128_HMAC_SHA1_32");
             srtp_video_updated = true;
         }
@@ -3457,7 +3457,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             if ((getSessionStateCurrent() == eNoSession) || (getSessionStateCurrent() == eCompleted))
             {
                 logSrtpInfo("call::createSendingMessage():  Marking preferred OFFER cryptosuite...\n");
-                strncat(_pref_video_cs_out, "NULL_HMAC_SHA1_80", sizeof(_pref_video_cs_out) - 1);
+                strcpy(_pref_video_cs_out, "NULL_HMAC_SHA1_80");
             }
             else if (getSessionStateCurrent() == eOfferReceived)
             {
@@ -3488,7 +3488,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
 
             pV.video_found = true;
-            strncat(pV.primary_video_cryptosuite, "NULL_HMAC_SHA1_80", sizeof(pV.primary_video_cryptosuite) - 1);
+            strcpy(pV.primary_video_cryptosuite, "NULL_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "NULL_HMAC_SHA1_80");
             srtp_video_updated = true;
         }
@@ -3508,7 +3508,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
                 _txUASVideo.selectHashAlgorithm(HMAC_SHA1_80, SECONDARY_CRYPTO);
             }
             pV.video_found = true;
-            strncat(pV.secondary_video_cryptosuite, "NULL_HMAC_SHA1_80", sizeof(pV.secondary_video_cryptosuite) - 1);
+            strcpy(pV.secondary_video_cryptosuite, "NULL_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "NULL_HMAC_SHA1_80");
             srtp_video_updated = true;
         }
@@ -3531,7 +3531,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             if ((getSessionStateCurrent() == eNoSession) || (getSessionStateCurrent() == eCompleted))
             {
                 logSrtpInfo("call::createSendingMessage():  Marking preferred OFFER cryptosuite...\n");
-                strncat(_pref_video_cs_out, "NULL_HMAC_SHA1_32", sizeof(_pref_video_cs_out) - 1);
+                strcpy(_pref_video_cs_out, "NULL_HMAC_SHA1_32");
             }
             else if (getSessionStateCurrent() == eOfferReceived)
             {
@@ -3562,7 +3562,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
 
             pV.video_found = true;
-            strncat(pV.primary_video_cryptosuite, "NULL_HMAC_SHA1_32", sizeof(pV.primary_video_cryptosuite) - 1);
+            strcpy(pV.primary_video_cryptosuite, "NULL_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "NULL_HMAC_SHA1_32");
             srtp_video_updated = true;
         }
@@ -3582,7 +3582,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
                 _txUASVideo.selectHashAlgorithm(HMAC_SHA1_32, SECONDARY_CRYPTO);
             }
             pV.video_found = true;
-            strncat(pV.secondary_video_cryptosuite, "NULL_HMAC_SHA1_32", sizeof(pV.secondary_video_cryptosuite) - 1);
+            strcpy(pV.secondary_video_cryptosuite, "NULL_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "NULL_HMAC_SHA1_32");
             srtp_video_updated = true;
         }
@@ -3687,7 +3687,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
             pV.video_found = true;
             pV.primary_unencrypted_video_srtp = true;
-            strncat(pV.primary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_80", sizeof(pV.primary_video_cryptosuite) - 1);
+            strcpy(pV.primary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "UNENCRYPTED_SRTP");
             srtp_video_updated = true;
         }
@@ -3708,7 +3708,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
             pV.video_found = true;
             pV.secondary_unencrypted_video_srtp = true;
-            strncat(pV.secondary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_80", sizeof(pV.secondary_video_cryptosuite) - 1);
+            strcpy(pV.secondary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_80");
             dest += snprintf(dest, left, "%s", "UNENCRYPTED_SRTP");
             srtp_video_updated = true;
         }
@@ -3729,7 +3729,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
             pV.video_found = true;
             pV.primary_unencrypted_video_srtp = true;
-            strncat(pV.primary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_32", sizeof(pV.primary_video_cryptosuite) - 1);
+            strcpy(pV.primary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "UNENCRYPTED_SRTP");
             srtp_video_updated = true;
         }
@@ -3750,7 +3750,7 @@ char* call::createSendingMessage(SendingMessage *src, int P_index, char *msg_buf
             }
             pV.video_found = true;
             pV.secondary_unencrypted_video_srtp = true;
-            strncat(pV.secondary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_32", sizeof(pV.secondary_video_cryptosuite) - 1);
+            strcpy(pV.secondary_video_cryptosuite, "AES_CM_128_HMAC_SHA1_32");
             dest += snprintf(dest, left, "%s", "UNENCRYPTED_SRTP");
             srtp_video_updated = true;
         }
@@ -4661,21 +4661,21 @@ bool call::process_incoming(const char* msg, const struct sockaddr_storage* src)
 
             pA.audio_found = false;
             pA.primary_audio_cryptotag = 0;
-            memset(pA.primary_audio_cryptosuite, 0, sizeof(pA.primary_audio_cryptosuite));
-            memset(pA.primary_audio_cryptokeyparams, 0, sizeof(pA.primary_audio_cryptokeyparams));
+            *pA.primary_audio_cryptosuite = 0;
+            *pA.primary_audio_cryptokeyparams = 0;
             pA.secondary_audio_cryptotag = 0;
-            memset(pA.secondary_audio_cryptosuite, 0, sizeof(pA.secondary_audio_cryptosuite));
-            memset(pA.secondary_audio_cryptokeyparams, 0, sizeof(pA.secondary_audio_cryptokeyparams));
+            *pA.secondary_audio_cryptosuite = 0;
+            *pA.secondary_audio_cryptokeyparams = 0;
             pA.primary_unencrypted_audio_srtp = false;
             pA.secondary_unencrypted_audio_srtp = false;
 
             pV.video_found = false;
             pV.primary_video_cryptotag = 0;
-            memset(pV.primary_video_cryptosuite, 0, sizeof(pV.primary_video_cryptosuite));
-            memset(pV.primary_video_cryptokeyparams, 0, sizeof(pV.primary_video_cryptokeyparams));
+            *pV.primary_video_cryptosuite = 0;
+            *pV.primary_video_cryptokeyparams = 0;
             pV.secondary_video_cryptotag = 0;
-            memset(pV.secondary_video_cryptosuite, 0, sizeof(pV.secondary_video_cryptosuite));
-            memset(pV.secondary_video_cryptokeyparams, 0, sizeof(pV.secondary_video_cryptokeyparams));
+            *pV.secondary_video_cryptosuite = 0;
+            *pV.secondary_video_cryptokeyparams = 0;
             pV.primary_unencrypted_video_srtp = false;
             pV.secondary_unencrypted_video_srtp = false;
 #endif // USE_TLS

--- a/src/jlsrtp.cpp
+++ b/src/jlsrtp.cpp
@@ -29,8 +29,6 @@
 #include <iterator>
 #include <sstream> // std::ostringstream
 
-extern unsigned int global_ssrc_id;
-
 // --------------- PRIVATE METHODS ----------------
 
 bool JLSRTP::isBase64(unsigned char c)
@@ -3518,10 +3516,7 @@ bool JLSRTP::operator!=(const JLSRTP& that)
 
 JLSRTP::JLSRTP()
 {
-    if (global_ssrc_id == 0) {
-        global_ssrc_id = rand();
-    }
-    resetCryptoContext(global_ssrc_id, "127.0.0.1", 0);
+    resetCryptoContext(0xCA110000, "127.0.0.1", 0);
 
     _pseudorandomstate.cipher = EVP_CIPHER_CTX_new();
     if (_pseudorandomstate.cipher != nullptr)
@@ -3536,7 +3531,7 @@ JLSRTP::JLSRTP()
     }
 }
 
-JLSRTP::JLSRTP(unsigned int ssrc, std::string ipAddress, unsigned short port)
+JLSRTP::JLSRTP(unsigned int ssrc, const std::string& ipAddress, unsigned short port)
 {
     resetCryptoContext(ssrc, ipAddress, port);
 
@@ -3565,6 +3560,10 @@ JLSRTP::~JLSRTP()
 #include "jlsrtp.hpp"
 
 JLSRTP::JLSRTP()
+{
+}
+
+JLSRTP::JLSRTP(unsigned int ssrc, const std::string& ipAddress, unsigned short port)
 {
 }
 

--- a/src/rtpstream.cpp
+++ b/src/rtpstream.cpp
@@ -3153,9 +3153,9 @@ int rtpstream_rtpecho_startaudio(rtpstream_callinfo_t* callinfo, JLSRTP& rxUASAu
 
     taskinfo->audio_srtp_echo_active = 1;
 
-    pthread_mutex_lock(&debugremutexaudio);
     if (srtpcheck_debug)
     {
+        pthread_mutex_lock(&debugremutexaudio);
         if (debugrefileaudio == nullptr)
         {
             debugrefileaudio = fopen("debugrefileaudio", "w");
@@ -3166,8 +3166,8 @@ int rtpstream_rtpecho_startaudio(rtpstream_callinfo_t* callinfo, JLSRTP& rxUASAu
                 return -2;
             }
         }
+        pthread_mutex_unlock(&debugremutexaudio);
     }
-    pthread_mutex_unlock(&debugremutexaudio);
 
     pthread_mutex_lock(&debugremutexaudio);
     if (debugrefileaudio != nullptr)
@@ -3326,9 +3326,9 @@ int rtpstream_rtpecho_startvideo(rtpstream_callinfo_t* callinfo, JLSRTP& rxUASVi
 
     taskinfo->video_srtp_echo_active = 1;
 
-    pthread_mutex_lock(&debugremutexvideo);
     if (srtpcheck_debug)
     {
+        pthread_mutex_lock(&debugremutexvideo);
         if (debugrefilevideo == nullptr)
         {
             debugrefilevideo = fopen("debugrefilevideo", "w");
@@ -3339,8 +3339,8 @@ int rtpstream_rtpecho_startvideo(rtpstream_callinfo_t* callinfo, JLSRTP& rxUASVi
                 return -2;
             }
         }
+        pthread_mutex_unlock(&debugremutexvideo);
     }
-    pthread_mutex_unlock(&debugremutexvideo);
 
     pthread_mutex_lock(&debugremutexvideo);
     if (debugrefilevideo != nullptr)

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -63,6 +63,7 @@ extern char** environ;
 
 extern SIPpSocket *ctrl_socket;
 extern SIPpSocket *stdin_socket;
+static bool random_base_ssrc = false;
 
 /* These could be local to main, but for the option processing table. */
 static int argiFileName;
@@ -291,6 +292,7 @@ struct sipp_option options_table[] = {
 #endif // USE_TLS
     {"audiotolerance", "Audio error tolerance for RTP checks (0.0-1.0) -- default: 1.0", SIPP_OPTION_FLOAT, &audiotolerance, 1},
     {"videotolerance", "Video error tolerance for RTP checks (0.0-1.0) -- default: 1.0", SIPP_OPTION_FLOAT, &videotolerance, 1},
+    {"random_base_ssrc", "Use a random base SSRC for RTP streams instead of default value 0xCA110000", SIPP_OPTION_SETFLAG, &random_base_ssrc, 1},
 
     {"", "Call rate options:", SIPP_HELP_TEXT_HEADER, nullptr, 0},
     {"r", "Set the call rate (in calls per seconds).  This value can be"
@@ -1946,6 +1948,13 @@ int main(int argc, char *argv[])
                 ERROR("Internal error: I don't recognize the option type for %s", argv[argi]);
             }
         }
+    }
+
+    /* generate random ssrc */
+    if (random_base_ssrc) {
+        global_ssrc_id = rand();
+    } else {
+        global_ssrc_id = 0xCA110000;
     }
 
     /* Load compression plugin if needed/available. */


### PR DESCRIPTION
This PR resolves regressions in the RTPCHECK functionality which were introduced right when it was merged in SIPp-3.7.0~rc1 back in 2023.

- Fixed crash occurring on RE-INVITEs when processing SRTP crypto parameters (was caused by incorrect substitution of strncat() instead of memset()+strncpy() when RTPCHECK functionality was first introduced in 3.7.0~rc1).
- Restored code to use timestamps in RTP echo action log file names in rtpstream_rtpecho_startaudio() -- this had been mistakenly taken out when RTPCHECK functionality was first instroduced in 3.7.0~rc1.
- Restored code to use timestamps in RTP echo action log file names in rtpstream_rtpecho_startvideo() -- this had been mistakenly taken out when RTPCHECK functionality was first instroduced in 3.7.0~rc1.
- Modified rtpstream_rtpecho_startaudio() to perform use safe open()/fdopen() APIs to restrict access to RTP echo action log file.
- Modified rtpstream_rtpecho_startvideo() to perform use safe open()/fdopen() APIs to restrict access to RTP echo action log file.
- Added dummy custom JLSRTP class constructor to allow providing (SSRC, IP, port) at construction time when using non-SSL builds (so that encapsulation can be maintained without the need for externs).
- Modified call class to use custom JLSRTP class constructor (to maintain encapsulation without the need for externs).
- Modified rtpstream code to use custom JLSRTP constructor (to maintain encapsulation without the need for externs).
- Parameterized global_ssrc_id to allow either maintaining legacy SIPP behavior (default constant SSRC required by RTPCHECK functionality) or randomly generating them (varying SSRC).
- Modified main sipp code to properly apply parameterized global_ssrc_id parameter.
