### PR TITLE
Fix const-correctness

### DIFF
--- a/include/prepare_pcap.h
+++ b/include/prepare_pcap.h
@@ -45,7 +45,7 @@ extern "C" {
     int check(uint16_t*, int);
     uint16_t checksum_carry(int);
     int prepare_pkts(const char*, pcap_pkts*);
-    int prepare_dtmf(const char*, pcap_pkts*, uint16_t start_seq_no);
+    int prepare_dtmf(char*, pcap_pkts*, uint16_t start_seq_no);
 #ifdef __cplusplus
 }
 #endif

--- a/src/prepare_pcap.c
+++ b/src/prepare_pcap.c
@@ -542,7 +542,7 @@ static void prepare_noop(
 
 /* prepare a dtmf pcap
  */
-int prepare_dtmf(const char* digits, pcap_pkts* pkts, uint16_t start_seq_no)
+int prepare_dtmf(char* digits, pcap_pkts* pkts, uint16_t start_seq_no)
 {
     unsigned long tone_len = 200;
     const u_long pktlen = sizeof(struct dtmfpacket);


### PR DESCRIPTION
We actually modify this argument so it must not be decribed as const.