### PR TITLE
Remove unused gmock - we don't use it

### DIFF
--- a/src/sipp_unittest.cpp
+++ b/src/sipp_unittest.cpp
@@ -20,7 +20,6 @@
 #include "sipp.hpp"
 
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 #include <string.h>
 
 int main(int argc, char* argv[])
@@ -29,7 +28,6 @@ int main(int argc, char* argv[])
     userVariables = new AllocVariableTable(globalVariables);
     main_scenario = new scenario(0, 0);
 
-    ::testing::GMOCK_FLAG(verbose) = "verbose";
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
The `GMOCK_FLAG(verbose)` line references gmock symbols. Since the codebase has no mock objects, this line was dead code anyway.