### PR TITLE
Revert "Fix for local_port keyword using TCP or TLS"

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -2591,11 +2591,6 @@ int open_connections()
         }
         sipp_customize_socket(tcp_multiplex);
 
-        /* This fixes local_port keyword value when transport are TCP|TLS and it's defined by user with "-p" */
-        if (sipp_bind_socket(tcp_multiplex, &local_sockaddr, nullptr)) {
-            ERROR_NO("Unable to bind TCP socket");
-        }
-
         if (tcp_multiplex->connect(&remote_sockaddr)) {
             if (reset_number > 0) {
                 WARNING("Failed to reconnect");


### PR DESCRIPTION
This causes every call with -t to fail with:
Unable to bind TCP socket, errno = 48 (Address already in use)

This reverts commit c4d9c9add063eff09f0b6662552bc6ccebc1b036.

Fixes #774.