### PR TITLE
Fix SDP extraction from multipart/mixed SIP message bodies

### DIFF
--- a/regress/github-#0862/run
+++ b/regress/github-#0862/run
@@ -1,0 +1,24 @@
+#!/bin/sh
+# This regression test is a part of SIPp.
+# Validate RTP extraction when INVITE body is multipart/mixed with SDP + PIDF-LO.
+. "`dirname "$0"`/../functions"; init
+
+uac_media_port=5072
+
+udplisten $uac_media_port >udplisten.log &
+udplisten_job=$!
+trap "kill -9 $udplisten_job 2>/dev/null" EXIT
+
+sippbg -sf uas.xml -i 127.0.0.1 -p 5070 -m 1
+sippfg -m 1 -sf uac.xml 127.0.0.1:5070 -i 127.0.0.1 \
+    -trace_msg -message_file tmp.log -timeout 6 -timeout_error >/dev/null 2>&1
+status=$?
+
+test $status -ne 0 && fail "SIPp UAC job failed"
+
+port=`sed -e '/^Connectionless from/!d;s/.*://' udplisten.log`
+if test -n "$port"; then
+    ok
+else
+    fail "got no RTP at all"
+fi

--- a/regress/github-#0862/uac.xml
+++ b/regress/github-#0862/uac.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario name="multipart-invite-with-pidf-lo">
+
+  <send retrans="500" start_txn="invite">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sip:[service]@[local_ip]:[local_port];tag=[pid]SIPpTag00[call_number]
+      To: sip:[service]@[remote_ip]:[remote_port]
+      Call-ID: [call_id]
+      CSeq: [cseq] INVITE
+      Contact: sip:[service]@[local_ip]:[local_port]
+      Content-Type: multipart/mixed; boundary=boundary42
+      Content-Length: [len]
+
+      --boundary42
+      Content-Type: application/sdp
+
+      v=0
+      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[local_ip_type] [local_ip]
+      t=0 0
+      m=audio 5072 RTP/AVP 8 0
+      a=rtpmap:8 PCMA/8000
+      a=rtpmap:0 PCMU/8000
+
+      --boundary42
+      Content-Type: application/pidf+xml
+
+      <?xml version="1.0" encoding="UTF-8"?>
+      <presence xmlns="urn:ietf:params:xml:ns:pidf"
+                xmlns:gp="urn:ietf:params:xml:ns:pidf:geopriv10"
+                xmlns:gml="http://www.opengis.net/gml"
+                entity="pres:alice@example.com">
+        <tuple id="t1">
+          <status><basic>open</basic></status>
+        </tuple>
+        <gp:geopriv>
+          <gp:location-info>
+            <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+              <gml:pos>37.7749 -122.4194</gml:pos>
+            </gml:Point>
+          </gp:location-info>
+        </gp:geopriv>
+      </presence>
+
+      --boundary42--
+
+    ]]>
+  </send>
+
+  <recv response="100" optional="true" response_txn="invite"/>
+  <recv response="180" optional="true" response_txn="invite"/>
+  <recv response="183" optional="true" response_txn="invite"/>
+  <recv response="200" rrs="true" response_txn="invite"/>
+
+  <send ack_txn="invite">
+    <![CDATA[
+
+      ACK [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      [routes]
+      From: sip:[service]@[local_ip]:[local_port];tag=[pid]SIPpTag00[call_number]
+      To: sip:[service]@[remote_ip]:[remote_port][peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: [cseq] ACK
+      Contact: sip:[service]@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv request="BYE"/>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_Record-Route:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+</scenario>

--- a/regress/github-#0862/uas.xml
+++ b/regress/github-#0862/uas.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+<scenario name="uas-rtp-after-multipart-invite">
+
+  <recv request="INVITE" rrs="true"/>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 180 Ringing
+      [last_Via:]
+      [last_Record-Route:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:[service]@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_Record-Route:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:[service]@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 8 0
+      a=rtpmap:8 PCMA/8000
+      a=rtpmap:0 PCMU/8000
+
+    ]]>
+  </send>
+
+  <recv request="ACK" rrs="true"/>
+
+  <nop>
+    <action>
+      <exec rtp_stream="beep_1sec_50x160b.alaw,-1,8,PCMA/8000"/>
+    </action>
+  </nop>
+
+  <pause milliseconds="800"/>
+
+  <send start_txn="bye" retrans="500">
+    <![CDATA[
+
+      BYE [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      [routes]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      CSeq: [cseq] BYE
+      Contact: sip:[service]@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv response="200" response_txn="bye"/>
+
+</scenario>

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -4571,8 +4571,13 @@ bool call::process_incoming(const char* msg, const struct sockaddr_storage* src)
         }
     }
 
-    /* Check if message has a SDP in it; and extract media information. */
-    if (!strcmp(get_header_content(msg, "Content-Type:"), "application/sdp") &&
+    /* Check if message has a SDP in it; and extract media information.
+     * Also handle multipart/mixed bodies that contain an application/sdp part
+     * (e.g. SIP messages carrying both SDP and PIDF-LO geolocation). */
+    const char* ct_hdr = get_header_content(msg, "Content-Type:");
+    bool has_sdp_content = !strcmp(ct_hdr, "application/sdp") ||
+                           (strstr(ct_hdr, "multipart/") && strstr(msg, "application/sdp"));
+    if (has_sdp_content &&
           (hasMedia == 1) &&
           (!curmsg->ignoresdp))
     {


### PR DESCRIPTION
## Summary

The Content-Type check in `process_incoming()` (call.cpp:4575) only matched `application/sdp` exactly, causing SIPp to skip SDP media extraction entirely when the body was `multipart/mixed`. This meant `rtp_stream`, PCAP play, and SRTP parameter extraction never ran for multipart messages.

## Problem

SIP messages carrying both SDP and PIDF-LO geolocation data (per RFC 5621 / RFC 5765) use `Content-Type: multipart/mixed` with the SDP in one MIME part. This is standard for E911 call flows. When SIPp received such an INVITE as a UAS, it never extracted the remote media address, so `rtp_stream` had no destination and sent zero RTP packets.

## Fix

Extend the Content-Type check to also match `multipart/*` bodies that contain an `application/sdp` part. The existing `find_in_sdp()` and `extract_rtp_remote_addr()` functions already search raw message text and work correctly with multipart content — they just were never called.

## Test plan

- SIPp UAS scenario receiving an INVITE with `Content-Type: multipart/mixed` containing SDP + PIDF-LO
- Verify `rtp_stream` sends audio (previously sent 0 packets)
- Verify plain `application/sdp` INVITEs still work as before