### PR TITLE
[codex] add multi-instance launcher

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Welcome to SIPp reference documentation!
    3PCC_extended
    controlling
    transport
+   multi_instance
    media
    statistics
    error

--- a/docs/multi_instance.rst
+++ b/docs/multi_instance.rst
@@ -1,0 +1,34 @@
+Multi-instance launcher
+=======================
+
+SIPp can launch several SIPp processes from one CSV configuration file.  This
+is useful when a test needs matching groups of UAC and UAS instances.
+
+Use ``-multi`` with a CSV file:
+
+.. code-block:: bash
+
+   ./sipp -multi multi.csv -multi_base_port 5060
+
+The CSV format is:
+
+.. code-block:: text
+
+   role,count,args
+   uas,2,"-sn uas -p {instance_port} -nostdin"
+   uac,2,"-sn uac 127.0.0.1:{instance_port} -m 100 -nostdin"
+
+Each row creates ``count`` child processes.  The ``args`` field is split like
+command-line arguments and passed to each child ``sipp`` process.
+
+The following placeholders are expanded in the ``args`` field:
+
+* ``{role}``: the role column value.
+* ``{instance}``: the zero-based instance number within that role.
+* ``{base_port}``: the value passed with ``-multi_base_port``.
+* ``{instance_port}``: ``base_port + instance``.  Use this to pair UAC and UAS
+  rows by instance number.
+* ``{port}``: a globally increasing port number for every child process.
+
+The launcher waits until all children exit and returns the first non-zero child
+exit code.  If all children exit successfully, the launcher exits with zero.

--- a/include/multi_instance.hpp
+++ b/include/multi_instance.hpp
@@ -1,0 +1,43 @@
+/*
+ * Multi-instance launcher support for SIPp.
+ */
+
+#ifndef __MULTI_INSTANCE__
+#define __MULTI_INSTANCE__
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+struct MultiInstanceSpec {
+    std::string role;
+    int count;
+    std::string args;
+};
+
+struct MultiInstanceCommand {
+    std::string role;
+    int instance;
+    int port;
+    std::vector<std::string> argv;
+};
+
+bool parse_multi_instance_csv(const std::string &csv,
+                              const std::string &source_name,
+                              std::vector<MultiInstanceSpec> *specs,
+                              std::string *error);
+
+bool parse_multi_instance_csv_file(const std::string &path,
+                                   std::vector<MultiInstanceSpec> *specs,
+                                   std::string *error);
+
+std::vector<MultiInstanceCommand>
+build_multi_instance_commands(const std::string &program_path,
+                              const std::vector<MultiInstanceSpec> &specs,
+                              int base_port);
+
+int run_multi_instance_commands(const std::vector<MultiInstanceCommand> &commands,
+                                std::ostream &out,
+                                std::ostream &err);
+
+#endif

--- a/include/sipp.hpp
+++ b/include/sipp.hpp
@@ -165,6 +165,12 @@ cmd messages are received */
 #define DEFAULT_BEHAVIOR_PINGREPLY   4
 #define DEFAULT_BEHAVIOR_BADCSEQ     8
 
+#define CID_MODE_FORMAT              0
+#define CID_MODE_UUID                1
+#define CID_MODE_UUID_COMPACT        2
+#define CID_MODE_RANDOM              3
+#define CID_MODE_TIMESTAMP           4
+
 #define DEFAULT_BEHAVIOR_ALL         (DEFAULT_BEHAVIOR_BYE | DEFAULT_BEHAVIOR_ABORTUNEXP | DEFAULT_BEHAVIOR_PINGREPLY | DEFAULT_BEHAVIOR_BADCSEQ)
 
 #define DEFAULT_MIN_RTP_PORT         DEFAULT_MEDIA_PORT
@@ -290,6 +296,7 @@ MAYBE_EXTERN int                currentRepartitionToDisplay  DEFVAL(1);
 MAYBE_EXTERN unsigned int       base_cseq               DEFVAL(0);
 MAYBE_EXTERN char             * auth_uri                DEFVAL(0);
 MAYBE_EXTERN const char       * call_id_string          DEFVAL("%u-%p@%s");
+MAYBE_EXTERN int                call_id_mode            DEFVAL(CID_MODE_FORMAT);
 typedef std::unordered_map<std::string, std::string> ParamMap;
 MAYBE_EXTERN ParamMap           generic;
 

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -39,6 +39,7 @@
  */
 
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -115,6 +116,170 @@ int call::stepDynamicId   = 4;                // FIXME both param to be in comma
 static const int SM_UNUSED = -1;
 
 static unsigned int next_number = 1;
+
+static void append_call_id_char(char *call_id, int &count, char value)
+{
+    if (count < MAX_HEADER_LEN - 1) {
+        call_id[count++] = value;
+    }
+    call_id[count] = '\0';
+}
+
+static void append_call_id_text(char *call_id, int &count, const char *fmt, ...)
+{
+    if (count >= MAX_HEADER_LEN - 1) {
+        call_id[MAX_HEADER_LEN - 1] = '\0';
+        return;
+    }
+
+    va_list ap;
+    va_start(ap, fmt);
+    int written = vsnprintf(&call_id[count], MAX_HEADER_LEN - count, fmt, ap);
+    va_end(ap);
+
+    if (written < 0) {
+        call_id[count] = '\0';
+        return;
+    }
+
+    if (written >= MAX_HEADER_LEN - count) {
+        count = MAX_HEADER_LEN - 1;
+    } else {
+        count += written;
+    }
+}
+
+static void fill_call_id_bytes(unsigned char *bytes, size_t size, unsigned int call_number)
+{
+    using clock = std::chrono::system_clock;
+    uint64_t seed = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            clock::now().time_since_epoch()).count());
+
+    seed ^= static_cast<uint64_t>(call_number) << 32;
+    seed ^= static_cast<uint64_t>(pid) << 8;
+
+    for (size_t i = 0; i < size; ++i) {
+        seed ^= static_cast<uint64_t>(rand()) << ((i % 4) * 8);
+        seed = seed * 2862933555777941757ULL + 3037000493ULL + i;
+        bytes[i] = static_cast<unsigned char>((seed >> ((i % 8) * 8)) & 0xff);
+    }
+}
+
+static void build_default_call_id(char *call_id, unsigned int call_number)
+{
+    const char *src = call_id_string;
+    int count = 0;
+
+    while (*src && count < MAX_HEADER_LEN - 1) {
+        if (*src == '%') {
+            ++src;
+            switch (*src++) {
+            case 'u':
+                append_call_id_text(call_id, count, "%u", call_number);
+                break;
+            case 'p':
+                append_call_id_text(call_id, count, "%u", pid);
+                break;
+            case 's':
+                append_call_id_text(call_id, count, "%s", local_ip);
+                break;
+            case 'r':
+                append_call_id_text(call_id, count, "%u", rand());
+                break;
+            default:
+                append_call_id_char(call_id, count, '%');
+                break;
+            }
+        } else {
+            append_call_id_char(call_id, count, *src++);
+        }
+    }
+    call_id[count] = '\0';
+}
+
+static void build_uuid_call_id(char *call_id, unsigned int call_number, bool compact)
+{
+    unsigned char bytes[16];
+    int count = 0;
+
+    fill_call_id_bytes(bytes, sizeof(bytes), call_number);
+    bytes[6] = static_cast<unsigned char>((bytes[6] & 0x0f) | 0x40);
+    bytes[8] = static_cast<unsigned char>((bytes[8] & 0x3f) | 0x80);
+
+    if (compact) {
+        append_call_id_text(call_id, count,
+                            "%02x%02x%02x%02x%02x%02x%02x%02x"
+                            "%02x%02x%02x%02x%02x%02x%02x%02x",
+                            bytes[0], bytes[1], bytes[2], bytes[3],
+                            bytes[4], bytes[5], bytes[6], bytes[7],
+                            bytes[8], bytes[9], bytes[10], bytes[11],
+                            bytes[12], bytes[13], bytes[14], bytes[15]);
+    } else {
+        append_call_id_text(call_id, count,
+                            "%02x%02x%02x%02x-%02x%02x-%02x%02x-"
+                            "%02x%02x-%02x%02x%02x%02x%02x%02x",
+                            bytes[0], bytes[1], bytes[2], bytes[3],
+                            bytes[4], bytes[5], bytes[6], bytes[7],
+                            bytes[8], bytes[9], bytes[10], bytes[11],
+                            bytes[12], bytes[13], bytes[14], bytes[15]);
+    }
+
+    append_call_id_text(call_id, count, "@%s", local_ip);
+}
+
+static void build_random_call_id(char *call_id, unsigned int call_number)
+{
+    unsigned char bytes[16];
+    int count = 0;
+
+    fill_call_id_bytes(bytes, sizeof(bytes), call_number);
+    append_call_id_text(call_id, count, "%u-", call_number);
+    append_call_id_text(call_id, count,
+                        "%02x%02x%02x%02x%02x%02x%02x%02x"
+                        "%02x%02x%02x%02x%02x%02x%02x%02x",
+                        bytes[0], bytes[1], bytes[2], bytes[3],
+                        bytes[4], bytes[5], bytes[6], bytes[7],
+                        bytes[8], bytes[9], bytes[10], bytes[11],
+                        bytes[12], bytes[13], bytes[14], bytes[15]);
+    append_call_id_text(call_id, count, "@%s", local_ip);
+}
+
+static void build_timestamp_call_id(char *call_id, unsigned int call_number)
+{
+    using clock = std::chrono::system_clock;
+    int count = 0;
+    unsigned long long micros = static_cast<unsigned long long>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            clock::now().time_since_epoch()).count());
+
+    append_call_id_text(call_id, count, "%llu-%u-%u@%s",
+                        micros, call_number, pid, local_ip);
+}
+
+static void build_call_id(char *call_id, unsigned int call_number)
+{
+    call_id[0] = '\0';
+
+    switch (call_id_mode) {
+    case CID_MODE_UUID:
+        build_uuid_call_id(call_id, call_number, false);
+        break;
+    case CID_MODE_UUID_COMPACT:
+        build_uuid_call_id(call_id, call_number, true);
+        break;
+    case CID_MODE_RANDOM:
+        build_random_call_id(call_id, call_number);
+        break;
+    case CID_MODE_TIMESTAMP:
+        build_timestamp_call_id(call_id, call_number);
+        break;
+    case CID_MODE_FORMAT:
+    default:
+        build_default_call_id(call_id, call_number);
+        break;
+    }
+}
 
 static unsigned int get_tdm_map_number()
 {
@@ -791,38 +956,11 @@ call *call::add_call(int userId, bool ipv6, struct sockaddr_storage *dest)
 {
     static char call_id[MAX_HEADER_LEN];
 
-    const char * src = call_id_string;
-    int count = 0;
-
     if(!next_number) {
         next_number ++;
     }
 
-    while (*src && count < MAX_HEADER_LEN-1) {
-        if (*src == '%') {
-            ++src;
-            switch(*src++) {
-            case 'u':
-                count += snprintf(&call_id[count], MAX_HEADER_LEN-count-1, "%u", next_number);
-                break;
-            case 'p':
-                count += snprintf(&call_id[count], MAX_HEADER_LEN-count-1, "%u", pid);
-                break;
-            case 's':
-                count += snprintf(&call_id[count], MAX_HEADER_LEN-count-1, "%s", local_ip);
-                break;
-            case 'r':
-                count += snprintf(&call_id[count], MAX_HEADER_LEN-count-1, "%u", rand());
-                break;
-            default:      // treat all unknown sequences as %%
-                call_id[count++] = '%';
-                break;
-            }
-        } else {
-            call_id[count++] = *src++;
-        }
-    }
-    call_id[count] = 0;
+    build_call_id(call_id, next_number);
 
     return new call(main_scenario, nullptr, dest, call_id, userId, ipv6, false /* Not Auto. */, false);
 }
@@ -6836,6 +6974,105 @@ const std::string test_sdp_v6 = "v=0\r\n"
                                 "t=0 0\r\n"
                                 "m=audio 12345 RTP/AVP 0\r\n"
                                 "a=rtpmap:0 PCMU/8000\r\n";
+
+static std::string call_id_body(const char *call_id)
+{
+    const char *separator = strchr(call_id, '@');
+    if (!separator) {
+        return call_id;
+    }
+    return std::string(call_id, separator - call_id);
+}
+
+static bool is_lower_hex_string(const std::string &value)
+{
+    return std::all_of(value.begin(), value.end(), [](unsigned char c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+    });
+}
+
+TEST(call_id, default_mode_uses_cid_str_template) {
+    char call_id[MAX_HEADER_LEN];
+
+    call_id_mode = CID_MODE_FORMAT;
+    call_id_string = "%u-%p@%s";
+    pid = 4321;
+    strcpy(local_ip, "192.0.2.10");
+
+    build_call_id(call_id, 77);
+    EXPECT_STREQ("77-4321@192.0.2.10", call_id);
+}
+
+TEST(call_id, uuid_mode_generates_rfc4122_value) {
+    char call_id[MAX_HEADER_LEN];
+
+    call_id_mode = CID_MODE_UUID;
+    pid = 9001;
+    strcpy(local_ip, "198.51.100.25");
+
+    build_call_id(call_id, 15);
+
+    std::string body = call_id_body(call_id);
+    ASSERT_EQ(body.size(), 36U);
+    EXPECT_EQ(body[8], '-');
+    EXPECT_EQ(body[13], '-');
+    EXPECT_EQ(body[18], '-');
+    EXPECT_EQ(body[23], '-');
+    EXPECT_EQ(body[14], '4');
+    EXPECT_TRUE(body[19] == '8' || body[19] == '9' || body[19] == 'a' || body[19] == 'b');
+    EXPECT_TRUE(is_lower_hex_string(body.substr(0, 8)));
+    EXPECT_TRUE(is_lower_hex_string(body.substr(9, 4)));
+    EXPECT_TRUE(is_lower_hex_string(body.substr(14, 4)));
+    EXPECT_TRUE(is_lower_hex_string(body.substr(19, 4)));
+    EXPECT_TRUE(is_lower_hex_string(body.substr(24, 12)));
+    EXPECT_NE(std::string(call_id).find("@198.51.100.25"), std::string::npos);
+}
+
+TEST(call_id, uuid_compact_mode_generates_hex_value) {
+    char call_id[MAX_HEADER_LEN];
+
+    call_id_mode = CID_MODE_UUID_COMPACT;
+    pid = 1337;
+    strcpy(local_ip, "203.0.113.8");
+
+    build_call_id(call_id, 22);
+
+    std::string body = call_id_body(call_id);
+    ASSERT_EQ(body.size(), 32U);
+    EXPECT_TRUE(is_lower_hex_string(body));
+    EXPECT_EQ(body[12], '4');
+    EXPECT_TRUE(body[16] == '8' || body[16] == '9' || body[16] == 'a' || body[16] == 'b');
+    EXPECT_NE(std::string(call_id).find("@203.0.113.8"), std::string::npos);
+}
+
+TEST(call_id, random_mode_generates_unique_token_with_call_number) {
+    char call_id[MAX_HEADER_LEN];
+
+    call_id_mode = CID_MODE_RANDOM;
+    pid = 5150;
+    strcpy(local_ip, "203.0.113.44");
+
+    build_call_id(call_id, 31);
+
+    std::string body = call_id_body(call_id);
+    ASSERT_EQ(body.rfind("31-", 0), 0U);
+    ASSERT_EQ(body.size(), 35U);
+    EXPECT_TRUE(is_lower_hex_string(body.substr(3)));
+    EXPECT_NE(std::string(call_id).find("@203.0.113.44"), std::string::npos);
+}
+
+TEST(call_id, timestamp_mode_embeds_call_number_and_pid) {
+    char call_id[MAX_HEADER_LEN];
+
+    call_id_mode = CID_MODE_TIMESTAMP;
+    pid = 2718;
+    strcpy(local_ip, "192.0.2.44");
+
+    build_call_id(call_id, 52);
+
+    std::string full_call_id(call_id);
+    EXPECT_NE(full_call_id.find("-52-2718@192.0.2.44"), std::string::npos);
+}
 
 TEST(sdp, parse_valid_sdp_msg) {
     ASSERT_EQ(find_in_sdp("c=IN IP4 ", test_sdp_v4), "127.0.0.1");

--- a/src/multi_instance.cpp
+++ b/src/multi_instance.cpp
@@ -1,0 +1,325 @@
+/*
+ * Multi-instance launcher support for SIPp.
+ */
+
+#include "multi_instance.hpp"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+static std::string trim_copy(const std::string &value)
+{
+    size_t first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return "";
+    }
+    size_t last = value.find_last_not_of(" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+static bool parse_csv_line(const std::string &line,
+                           std::vector<std::string> *fields,
+                           std::string *error)
+{
+    fields->clear();
+    std::string current;
+    bool in_quotes = false;
+
+    for (size_t i = 0; i < line.size(); ++i) {
+        char ch = line[i];
+        if (in_quotes) {
+            if (ch == '"') {
+                if ((i + 1 < line.size()) && line[i + 1] == '"') {
+                    current.push_back('"');
+                    ++i;
+                } else {
+                    in_quotes = false;
+                }
+            } else {
+                current.push_back(ch);
+            }
+        } else if (ch == '"') {
+            in_quotes = true;
+        } else if (ch == ',') {
+            fields->push_back(trim_copy(current));
+            current.clear();
+        } else {
+            current.push_back(ch);
+        }
+    }
+
+    if (in_quotes) {
+        *error = "unterminated quoted CSV field";
+        return false;
+    }
+
+    fields->push_back(trim_copy(current));
+    return true;
+}
+
+static bool split_args(const std::string &args,
+                       std::vector<std::string> *words,
+                       std::string *error)
+{
+    words->clear();
+    std::string current;
+    char quote = 0;
+    bool escaping = false;
+
+    for (char ch : args) {
+        if (escaping) {
+            current.push_back(ch);
+            escaping = false;
+            continue;
+        }
+        if (ch == '\\') {
+            escaping = true;
+            continue;
+        }
+        if (quote) {
+            if (ch == quote) {
+                quote = 0;
+            } else {
+                current.push_back(ch);
+            }
+            continue;
+        }
+        if (ch == '\'' || ch == '"') {
+            quote = ch;
+        } else if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n') {
+            if (!current.empty()) {
+                words->push_back(current);
+                current.clear();
+            }
+        } else {
+            current.push_back(ch);
+        }
+    }
+
+    if (escaping) {
+        current.push_back('\\');
+    }
+    if (quote) {
+        *error = "unterminated quoted argument";
+        return false;
+    }
+    if (!current.empty()) {
+        words->push_back(current);
+    }
+
+    return true;
+}
+
+static void replace_all(std::string *value,
+                        const std::string &needle,
+                        const std::string &replacement)
+{
+    size_t pos = 0;
+    while ((pos = value->find(needle, pos)) != std::string::npos) {
+        value->replace(pos, needle.size(), replacement);
+        pos += replacement.size();
+    }
+}
+
+bool parse_multi_instance_csv(const std::string &csv,
+                              const std::string &source_name,
+                              std::vector<MultiInstanceSpec> *specs,
+                              std::string *error)
+{
+    specs->clear();
+    std::istringstream input(csv);
+    std::string line;
+    int line_number = 0;
+
+    while (std::getline(input, line)) {
+        ++line_number;
+        if (!line.empty() && line[line.size() - 1] == '\r') {
+            line.erase(line.size() - 1);
+        }
+        std::string trimmed = trim_copy(line);
+        if (trimmed.empty() || trimmed[0] == '#') {
+            continue;
+        }
+
+        std::vector<std::string> fields;
+        std::string parse_error;
+        if (!parse_csv_line(line, &fields, &parse_error)) {
+            *error = source_name + ":" + std::to_string(line_number) + ": " + parse_error;
+            return false;
+        }
+
+        if (fields.size() != 3) {
+            *error = source_name + ":" + std::to_string(line_number) +
+                     ": expected role,count,args";
+            return false;
+        }
+
+        if (line_number == 1 && fields[0] == "role" && fields[1] == "count" &&
+            fields[2] == "args") {
+            continue;
+        }
+
+        char *end = nullptr;
+        long count = strtol(fields[1].c_str(), &end, 10);
+        if (*end != '\0') {
+            *error = source_name + ":" + std::to_string(line_number) +
+                     ": count must be a number";
+            return false;
+        }
+        if (count <= 0) {
+            *error = source_name + ":" + std::to_string(line_number) +
+                     ": count must be greater than zero";
+            return false;
+        }
+        if (fields[0].empty()) {
+            *error = source_name + ":" + std::to_string(line_number) +
+                     ": role must not be empty";
+            return false;
+        }
+
+        std::vector<std::string> unused_words;
+        if (!split_args(fields[2], &unused_words, error)) {
+            *error = source_name + ":" + std::to_string(line_number) + ": " + *error;
+            return false;
+        }
+
+        MultiInstanceSpec spec;
+        spec.role = fields[0];
+        spec.count = static_cast<int>(count);
+        spec.args = fields[2];
+        specs->push_back(spec);
+    }
+
+    if (specs->empty()) {
+        *error = source_name + ": no multi-instance rows found";
+        return false;
+    }
+
+    return true;
+}
+
+bool parse_multi_instance_csv_file(const std::string &path,
+                                   std::vector<MultiInstanceSpec> *specs,
+                                   std::string *error)
+{
+    std::ifstream file(path);
+    if (!file.good()) {
+        *error = "unable to open multi-instance file: " + path;
+        return false;
+    }
+
+    std::ostringstream contents;
+    contents << file.rdbuf();
+    return parse_multi_instance_csv(contents.str(), path, specs, error);
+}
+
+std::vector<MultiInstanceCommand>
+build_multi_instance_commands(const std::string &program_path,
+                              const std::vector<MultiInstanceSpec> &specs,
+                              int base_port)
+{
+    std::vector<MultiInstanceCommand> commands;
+    int next_port = base_port;
+
+    for (const MultiInstanceSpec &spec : specs) {
+        for (int instance = 0; instance < spec.count; ++instance) {
+            std::string expanded = spec.args;
+            int instance_port = base_port + instance;
+            replace_all(&expanded, "{role}", spec.role);
+            replace_all(&expanded, "{instance}", std::to_string(instance));
+            replace_all(&expanded, "{instance_port}", std::to_string(instance_port));
+            replace_all(&expanded, "{base_port}", std::to_string(base_port));
+            replace_all(&expanded, "{port}", std::to_string(next_port));
+
+            std::vector<std::string> words;
+            std::string error;
+            if (!split_args(expanded, &words, &error)) {
+                words.clear();
+            }
+
+            MultiInstanceCommand command;
+            command.role = spec.role;
+            command.instance = instance;
+            command.port = next_port;
+            command.argv.push_back(program_path);
+            command.argv.insert(command.argv.end(), words.begin(), words.end());
+            commands.push_back(command);
+            ++next_port;
+        }
+    }
+
+    return commands;
+}
+
+int run_multi_instance_commands(const std::vector<MultiInstanceCommand> &commands,
+                                std::ostream &out,
+                                std::ostream &err)
+{
+    std::vector<pid_t> children;
+    int exit_code = 0;
+
+    for (const MultiInstanceCommand &command : commands) {
+        out << "Starting " << command.role << "[" << command.instance << "]";
+        if (command.port > 0) {
+            out << " port=" << command.port;
+        }
+        out << ":";
+        for (const std::string &arg : command.argv) {
+            out << " " << arg;
+        }
+        out << "\n";
+        out.flush();
+
+        pid_t child = fork();
+        if (child < 0) {
+            err << "fork failed: " << strerror(errno) << "\n";
+            exit_code = 1;
+            break;
+        }
+        if (child == 0) {
+            std::vector<char *> argv;
+            argv.reserve(command.argv.size() + 1);
+            for (const std::string &arg : command.argv) {
+                argv.push_back(const_cast<char *>(arg.c_str()));
+            }
+            argv.push_back(nullptr);
+            execvp(argv[0], argv.data());
+            std::cerr << "exec failed for " << argv[0] << ": " << strerror(errno) << "\n";
+            _exit(127);
+        }
+        children.push_back(child);
+    }
+
+    for (pid_t child : children) {
+        int status = 0;
+        while (waitpid(child, &status, 0) < 0) {
+            if (errno != EINTR) {
+                err << "waitpid failed for " << child << ": " << strerror(errno) << "\n";
+                exit_code = 1;
+                break;
+            }
+        }
+        if (WIFEXITED(status)) {
+            int child_exit = WEXITSTATUS(status);
+            if (child_exit != 0 && exit_code == 0) {
+                exit_code = child_exit;
+            }
+        } else if (WIFSIGNALED(status)) {
+            int signal_number = WTERMSIG(status);
+            if (exit_code == 0) {
+                exit_code = 128 + signal_number;
+            }
+        }
+    }
+
+    return exit_code;
+}

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -40,11 +40,15 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <algorithm>
 #include <atomic>
+#include <cctype>
+#include <iostream>
+#include <sstream>
 #include <string>
-#include <vector>
-#include <thread>
 #include <chrono>
+#include <thread>
+#include <vector>
 
 #ifdef __APPLE__
 /* Provide OSX version of extern char **environ; */
@@ -122,7 +126,367 @@ struct sipp_option {
 #define SIPP_OPTION_NEED_SCTP     39
 #define SIPP_OPTION_RX_SCENARIO   40
 #define SIPP_OPTION_RX_INPUT_FILE 41
+#define SIPP_OPTION_CID_TYPE      42
 #define SIPP_HELP_TEXT_HEADER    255
+
+struct wizard_scenario_option {
+    const char *scenario_name;
+    const char *description;
+    bool needs_remote_host;
+    bool use_scenario_file;
+};
+
+static const wizard_scenario_option wizard_scenarios[] = {
+    {"uac", "Embedded UAC client scenario.", true, false},
+    {"uas", "Embedded UAS server scenario.", false, false},
+    {"regexp", "Embedded UAC scenario with regexp and variables.", true, false},
+    {"branchc", "Embedded client branching scenario.", true, false},
+    {"branchs", "Embedded server branching scenario.", false, false},
+    {"uac_pcap", "Embedded UAC scenario with PCAP media playback.", true, false},
+    {"custom", "Custom XML scenario file.", false, true},
+};
+
+static std::string trim_copy(const std::string &value)
+{
+    size_t first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return "";
+    }
+
+    size_t last = value.find_last_not_of(" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+static std::string lowercase_copy(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value;
+}
+
+static bool wizard_cancelled(const std::string &value)
+{
+    std::string lowered = lowercase_copy(trim_copy(value));
+    return lowered == "q" || lowered == "quit" || lowered == "exit";
+}
+
+static bool wizard_prompt_line(const std::string &prompt, std::string *result, const char *default_value = nullptr)
+{
+    std::cout << prompt;
+    std::cout.flush();
+
+    if (!std::getline(std::cin, *result)) {
+        std::cout << "\n";
+        return false;
+    }
+
+    *result = trim_copy(*result);
+    if (wizard_cancelled(*result)) {
+        return false;
+    }
+
+    if (result->empty() && default_value) {
+        *result = default_value;
+    }
+
+    return true;
+}
+
+static bool parse_call_id_mode(const std::string &value, int *mode)
+{
+    std::string lowered = lowercase_copy(trim_copy(value));
+
+    if (lowered == "default" || lowered == "format" || lowered == "legacy") {
+        *mode = CID_MODE_FORMAT;
+        return true;
+    }
+    if (lowered == "uuid") {
+        *mode = CID_MODE_UUID;
+        return true;
+    }
+    if (lowered == "uuid-compact" || lowered == "uuidcompact" || lowered == "uuid32") {
+        *mode = CID_MODE_UUID_COMPACT;
+        return true;
+    }
+    if (lowered == "random" || lowered == "random-hex") {
+        *mode = CID_MODE_RANDOM;
+        return true;
+    }
+    if (lowered == "timestamp" || lowered == "time") {
+        *mode = CID_MODE_TIMESTAMP;
+        return true;
+    }
+
+    return false;
+}
+
+static bool parse_transport_choice(const std::string &value, std::string *transport_arg)
+{
+    std::string lowered = lowercase_copy(trim_copy(value));
+
+    if (lowered == "udp" || lowered == "u1") {
+        *transport_arg = "u1";
+        return true;
+    }
+    if (lowered == "tcp" || lowered == "t1") {
+        *transport_arg = "t1";
+        return true;
+    }
+    if (lowered == "tls" || lowered == "l1") {
+        *transport_arg = "l1";
+        return true;
+    }
+#ifdef USE_SCTP
+    if (lowered == "sctp" || lowered == "s1") {
+        *transport_arg = "s1";
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+static std::vector<std::string> split_simple_args(const std::string &input)
+{
+    std::vector<std::string> result;
+    std::istringstream words(input);
+    std::string word;
+
+    while (words >> word) {
+        result.push_back(word);
+    }
+
+    return result;
+}
+
+static bool should_launch_startup_wizard(int argc)
+{
+    return argc < 2 && isatty(STDIN_FILENO) && isatty(STDOUT_FILENO);
+}
+
+static std::vector<std::string> launch_startup_wizard(const char *program_name)
+{
+    std::vector<std::string> args;
+    const wizard_scenario_option *scenario_choice = nullptr;
+    std::string input;
+    std::string transport_arg = "u1";
+    std::string scenario_path;
+    std::string remote_host_value;
+    std::string service_value;
+    std::string rate_value;
+    std::string max_calls_value;
+    std::string concurrent_calls_value;
+    std::string extra_args;
+    int selected_call_id_mode = CID_MODE_FORMAT;
+    bool custom_scenario_uses_remote_host = false;
+
+    std::cout
+        << "\nSIPp startup wizard\n"
+        << "Press Enter to accept defaults. Type 'q' to quit.\n\n";
+
+    while (!scenario_choice) {
+        std::cout << "Scenario:\n";
+        for (size_t i = 0; i < sizeof(wizard_scenarios) / sizeof(wizard_scenarios[0]); ++i) {
+            std::cout << "  " << (i + 1) << ") " << wizard_scenarios[i].scenario_name
+                      << " - " << wizard_scenarios[i].description << "\n";
+        }
+        std::cout << "\n";
+
+        if (!wizard_prompt_line("Choose a scenario [1]: ", &input, "1")) {
+            return {};
+        }
+
+        std::string lowered = lowercase_copy(input);
+        size_t numeric_choice = 0;
+        if (!lowered.empty() &&
+                std::all_of(lowered.begin(), lowered.end(),
+                            [](unsigned char c) { return std::isdigit(c) != 0; })) {
+            numeric_choice = static_cast<size_t>(strtoul(lowered.c_str(), nullptr, 10));
+        }
+
+        if (numeric_choice >= 1 &&
+                numeric_choice <= (sizeof(wizard_scenarios) / sizeof(wizard_scenarios[0]))) {
+            scenario_choice = &wizard_scenarios[numeric_choice - 1];
+            break;
+        }
+
+        for (const wizard_scenario_option &candidate : wizard_scenarios) {
+            if (lowered == lowercase_copy(candidate.scenario_name)) {
+                scenario_choice = &candidate;
+                break;
+            }
+        }
+
+        if (!scenario_choice) {
+            std::cout << "Unknown scenario choice. Please select one of the listed items.\n\n";
+        }
+    }
+
+    if (scenario_choice->use_scenario_file) {
+        while (true) {
+            if (!wizard_prompt_line("Path to XML scenario file: ", &scenario_path)) {
+                return {};
+            }
+            if (scenario_path.empty()) {
+                std::cout << "A scenario path is required.\n";
+                continue;
+            }
+            if (access(scenario_path.c_str(), R_OK) != 0) {
+                std::cout << "Unable to read '" << scenario_path << "'. Try another path.\n";
+                continue;
+            }
+            break;
+        }
+
+        while (true) {
+            if (!wizard_prompt_line("Does this scenario send calls to a remote host? [y/N]: ",
+                                    &input, "n")) {
+                return {};
+            }
+
+            std::string lowered = lowercase_copy(input);
+            if (lowered == "y" || lowered == "yes") {
+                custom_scenario_uses_remote_host = true;
+                break;
+            }
+            if (lowered == "n" || lowered == "no") {
+                custom_scenario_uses_remote_host = false;
+                break;
+            }
+
+            std::cout << "Please answer y or n.\n";
+        }
+    }
+
+    if (scenario_choice->needs_remote_host || custom_scenario_uses_remote_host) {
+        while (remote_host_value.empty()) {
+            if (!wizard_prompt_line("Remote host[:port] [127.0.0.1]: ", &remote_host_value, "127.0.0.1")) {
+                return {};
+            }
+            if (remote_host_value.empty()) {
+                std::cout << "A remote host is required for this scenario.\n";
+            }
+        }
+    }
+
+    while (true) {
+#ifdef USE_SCTP
+        const char *transport_prompt = "Transport [udp/tcp/tls/sctp] (default udp): ";
+#else
+        const char *transport_prompt = "Transport [udp/tcp/tls] (default udp): ";
+#endif
+        if (!wizard_prompt_line(transport_prompt, &input, "udp")) {
+            return {};
+        }
+        if (parse_transport_choice(input, &transport_arg)) {
+            break;
+        }
+        std::cout << "Unknown transport. Use udp, tcp, tls";
+#ifdef USE_SCTP
+        std::cout << ", or sctp";
+#endif
+        std::cout << ".\n";
+    }
+
+    if (scenario_choice->needs_remote_host) {
+        if (!wizard_prompt_line("Request URI user (-s) [service]: ", &service_value, DEFAULT_SERVICE)) {
+            return {};
+        }
+    }
+
+    if (scenario_choice->needs_remote_host || custom_scenario_uses_remote_host) {
+        if (!wizard_prompt_line("Call rate (-r) [10]: ", &rate_value, "10")) {
+            return {};
+        }
+        if (!wizard_prompt_line("Max calls (-m, blank for unlimited): ", &max_calls_value)) {
+            return {};
+        }
+        if (!wizard_prompt_line("Max simultaneous calls (-l, optional): ", &concurrent_calls_value)) {
+            return {};
+        }
+    }
+
+    while (true) {
+        if (!wizard_prompt_line("Call-ID mode [default/uuid/uuid-compact/random/timestamp] (default default): ",
+                                &input, "default")) {
+            return {};
+        }
+        if (parse_call_id_mode(input, &selected_call_id_mode)) {
+            break;
+        }
+        std::cout << "Unknown Call-ID mode. Use default, uuid, uuid-compact, random, or timestamp.\n";
+    }
+
+    if (!wizard_prompt_line("Extra SIPp options (optional, space-separated): ", &extra_args)) {
+        return {};
+    }
+
+    args.push_back(program_name);
+    if (scenario_choice->use_scenario_file) {
+        args.push_back("-sf");
+        args.push_back(scenario_path);
+    } else {
+        args.push_back("-sn");
+        args.push_back(scenario_choice->scenario_name);
+    }
+
+    args.push_back("-t");
+    args.push_back(transport_arg);
+
+    if (!service_value.empty()) {
+        args.push_back("-s");
+        args.push_back(service_value);
+    }
+    if (!rate_value.empty()) {
+        args.push_back("-r");
+        args.push_back(rate_value);
+    }
+    if (!max_calls_value.empty()) {
+        args.push_back("-m");
+        args.push_back(max_calls_value);
+    }
+    if (!concurrent_calls_value.empty()) {
+        args.push_back("-l");
+        args.push_back(concurrent_calls_value);
+    }
+    if (selected_call_id_mode != CID_MODE_FORMAT) {
+        static const char *mode_names[] = {
+            "default",
+            "uuid",
+            "uuid-compact",
+            "random",
+            "timestamp",
+        };
+        args.push_back("-cid_type");
+        args.push_back(mode_names[selected_call_id_mode]);
+    }
+    if (!remote_host_value.empty()) {
+        args.push_back(remote_host_value);
+    }
+
+    std::vector<std::string> extra_words = split_simple_args(extra_args);
+    args.insert(args.end(), extra_words.begin(), extra_words.end());
+
+    std::cout << "\nCommand:\n  ";
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (i != 0) {
+            std::cout << " ";
+        }
+        std::cout << args[i];
+    }
+    std::cout << "\n\n";
+
+    if (!wizard_prompt_line("Run this command now? [Y/n]: ", &input, "y")) {
+        return {};
+    }
+    std::string lowered = lowercase_copy(input);
+    if (!(lowered == "y" || lowered == "yes")) {
+        std::cout << "Wizard cancelled.\n";
+        return {};
+    }
+
+    return args;
+}
 
 /* Put each option, its help text, and type in this table. */
 struct sipp_option options_table[] = {
@@ -234,6 +598,7 @@ struct sipp_option options_table[] = {
     {"aa", "Enable automatic 200 OK answer for INFO, NOTIFY, OPTIONS and UPDATE.", SIPP_OPTION_SETFLAG, &auto_answer, 1},
     {"base_cseq", "Start value of [cseq] for each call.", SIPP_OPTION_CSEQ, nullptr, 1},
     {"cid_str", "Call ID string (default %u-%p@%s).  %u=call_number, %s=ip_address, %p=process_number, %r=random_integer, %%=% (in any order).", SIPP_OPTION_STRING, &call_id_string, 1},
+    {"cid_type", "Call ID generation mode. Values: default, uuid, uuid-compact, random, timestamp. Modes other than default ignore -cid_str.", SIPP_OPTION_CID_TYPE, nullptr, 1},
     {"d", "Controls the length of calls. More precisely, this controls the duration of 'pause' instructions in the scenario, if they do not have a 'milliseconds' section. Default value is 0 and default unit is milliseconds.", SIPP_OPTION_TIME_MS, &duration, 1},
     {"deadcall_wait", "How long the Call-ID and final status of calls should be kept to improve message and error logs (default unit is ms).", SIPP_OPTION_TIME_MS, &deadcall_wait, 1},
     {"auth_uri", "Force the value of the URI for authentication.\n"
@@ -864,9 +1229,12 @@ static void help()
      "Usage:\n"
      "\n"
      "  sipp remote_host[:remote_port] [options]\n"
+     "  sipp\n"
      "\n"
      "Example:\n"
      "\n"
+     "   Launch the interactive startup wizard:\n"
+     "     ./sipp\n"
      "   Run SIPp with embedded server (uas) scenario:\n"
      "     ./sipp -sn uas\n"
      "   On the same host, run SIPp with embedded client (uac) scenario:\n"
@@ -1361,17 +1729,32 @@ int main(int argc, char *argv[])
     bool                 slave_masterSet = false;
     int rtp_errors;
     int echo_errors;
+    std::vector<std::string> wizard_args_storage;
+    std::vector<char *> wizard_argv;
 
     rtp_errors = 0;
     echo_errors = 0;
 
     randomseed();
 
-    /* At least one argument is needed */
-    if (argc < 2) {
+    if (should_launch_startup_wizard(argc)) {
+        wizard_args_storage = launch_startup_wizard(argv[0]);
+        if (wizard_args_storage.empty()) {
+            exit(EXIT_OTHER);
+        }
+
+        wizard_argv.reserve(wizard_args_storage.size());
+        for (std::string &value : wizard_args_storage) {
+            wizard_argv.push_back(value.data());
+        }
+
+        argc = static_cast<int>(wizard_argv.size());
+        argv = wizard_argv.data();
+    } else if (argc < 2) {
         help();
         exit(EXIT_OTHER);
     }
+
     {
         /* Ignore the SIGPIPE signal */
         struct sigaction action_pipe;
@@ -1514,6 +1897,13 @@ int main(int argc, char *argv[])
                 REQUIRE_ARG();
                 CHECK_PASS();
                 *((char**)option->data) = argv[argi];
+                break;
+            case SIPP_OPTION_CID_TYPE:
+                REQUIRE_ARG();
+                CHECK_PASS();
+                if (!parse_call_id_mode(argv[argi], &call_id_mode)) {
+                    ERROR("Unknown Call-ID mode '%s'. Use default, uuid, uuid-compact, random, or timestamp.", argv[argi]);
+                }
                 break;
             case SIPP_OPTION_ARGI:
                 REQUIRE_ARG();

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -60,6 +60,7 @@ extern char** environ;
 #define GLOBALS_FULL_DEFINITION
 #include "sipp.hpp"
 
+#include "multi_instance.hpp"
 #include "sip_parser.hpp"
 #include "socket.hpp"
 #include "logger.hpp"
@@ -127,6 +128,7 @@ struct sipp_option {
 #define SIPP_OPTION_RX_SCENARIO   40
 #define SIPP_OPTION_RX_INPUT_FILE 41
 #define SIPP_OPTION_CID_TYPE      42
+#define SIPP_OPTION_MULTI         43
 #define SIPP_HELP_TEXT_HEADER    255
 
 struct wizard_scenario_option {
@@ -584,6 +586,10 @@ struct sipp_option options_table[] = {
    {"buff_size", "Set the send and receive buffer size.", SIPP_OPTION_INT, &buff_size, 1},
    {"sendbuffer_warn", "Produce warnings instead of errors on SendBuffer failures.", SIPP_OPTION_BOOL, &sendbuffer_warn, 1},
    {"lost", "Set the number of packets to lose by default (scenario specifications override this value).", SIPP_OPTION_FLOAT, &global_lost, 1},
+   {"multi", "Launch multiple SIPp instances from a CSV file and wait for all of them to exit.\n"
+    "CSV format: role,count,args. The args field is split like shell arguments and supports {role}, {instance}, {base_port}, {instance_port}, and {port} placeholders.\n"
+    "Example row: uas,2,\"-sn uas -p {port}\"", SIPP_OPTION_MULTI, nullptr, 0},
+   {"multi_base_port", "Set the first {port} value used by -multi. Default is 5060.", SIPP_OPTION_MULTI, nullptr, 0},
    {"key", "keyword value\nSet the generic parameter named \"keyword\" to \"value\".", SIPP_OPTION_KEY, nullptr, 1},
    {"set", "variable value\nSet the global variable parameter named \"variable\" to \"value\".", SIPP_OPTION_VAR, nullptr, 3},
    {"tdmmap", "Generate and handle a table of TDM circuits.\n"
@@ -1721,6 +1727,67 @@ void randomseed(void)
     srand(seed);
 }
 
+static bool get_multi_arg(int argc,
+                          char *argv[],
+                          int *argi,
+                          const char *option,
+                          std::string *value)
+{
+    if ((*argi + 1) >= argc) {
+        std::cerr << "Missing argument for " << option << "\n";
+        return false;
+    }
+    ++(*argi);
+    *value = argv[*argi];
+    return true;
+}
+
+static bool maybe_run_multi_instance(int argc, char *argv[], int *exit_code)
+{
+    std::string config_path;
+    int base_port = DEFAULT_PORT;
+
+    for (int argi = 1; argi < argc; ++argi) {
+        if (!strcmp(argv[argi], "-multi")) {
+            if (!get_multi_arg(argc, argv, &argi, "-multi", &config_path)) {
+                *exit_code = EXIT_OTHER;
+                return true;
+            }
+        } else if (!strcmp(argv[argi], "-multi_base_port")) {
+            std::string value;
+            if (!get_multi_arg(argc, argv, &argi, "-multi_base_port", &value)) {
+                *exit_code = EXIT_OTHER;
+                return true;
+            }
+            char *end = nullptr;
+            long parsed_port = strtol(value.c_str(), &end, 10);
+            if (*end != '\0' || parsed_port <= 0 || parsed_port > 65535) {
+                std::cerr << "Invalid -multi_base_port value: " << value << "\n";
+                *exit_code = EXIT_OTHER;
+                return true;
+            }
+            base_port = static_cast<int>(parsed_port);
+        }
+    }
+
+    if (config_path.empty()) {
+        return false;
+    }
+
+    std::vector<MultiInstanceSpec> specs;
+    std::string error;
+    if (!parse_multi_instance_csv_file(config_path, &specs, &error)) {
+        std::cerr << error << "\n";
+        *exit_code = EXIT_OTHER;
+        return true;
+    }
+
+    std::vector<MultiInstanceCommand> commands =
+        build_multi_instance_commands(argv[0], specs, base_port);
+    *exit_code = run_multi_instance_commands(commands, std::cout, std::cerr);
+    return true;
+}
+
 /* Main */
 int main(int argc, char *argv[])
 {
@@ -1736,6 +1803,11 @@ int main(int argc, char *argv[])
     echo_errors = 0;
 
     randomseed();
+
+    int multi_exit_code = 0;
+    if (maybe_run_multi_instance(argc, argv, &multi_exit_code)) {
+        return multi_exit_code;
+    }
 
     if (should_launch_startup_wizard(argc)) {
         wizard_args_storage = launch_startup_wizard(argv[0]);

--- a/src/sipp_unittest.cpp
+++ b/src/sipp_unittest.cpp
@@ -19,6 +19,8 @@
 #define GLOBALS_FULL_DEFINITION
 #include "sipp.hpp"
 
+#include "multi_instance.hpp"
+
 #include "gtest/gtest.h"
 #include <string.h>
 
@@ -38,4 +40,45 @@ int main(int argc, char* argv[])
 void sipp_exit(int rc, int rtp_errors, int echo_errors)
 {
     exit(rc);
+}
+
+TEST(MultiInstanceConfig, ParsesQuotedCsvAndExpandsInstanceArguments)
+{
+    const std::string csv =
+        "role,count,args\n"
+        "uas,2,\"-sn uas -p {port}\"\n"
+        "uac,2,\"-sn uac 127.0.0.1:{instance_port} -key role {role} -key idx {instance}\"\n";
+
+    std::string error;
+    std::vector<MultiInstanceSpec> specs;
+
+    ASSERT_TRUE(parse_multi_instance_csv(csv, "inline.csv", &specs, &error)) << error;
+    ASSERT_EQ(2u, specs.size());
+    EXPECT_EQ("uas", specs[0].role);
+    EXPECT_EQ(2, specs[0].count);
+    EXPECT_EQ("-sn uas -p {port}", specs[0].args);
+    EXPECT_EQ("uac", specs[1].role);
+    EXPECT_EQ(2, specs[1].count);
+
+    std::vector<MultiInstanceCommand> commands =
+        build_multi_instance_commands("./sipp", specs, 5060);
+
+    ASSERT_EQ(4u, commands.size());
+    EXPECT_EQ(std::vector<std::string>({"./sipp", "-sn", "uas", "-p", "5060"}), commands[0].argv);
+    EXPECT_EQ(std::vector<std::string>({"./sipp", "-sn", "uas", "-p", "5061"}), commands[1].argv);
+    EXPECT_EQ(std::vector<std::string>({"./sipp", "-sn", "uac", "127.0.0.1:5060", "-key", "role", "uac", "-key", "idx", "0"}), commands[2].argv);
+    EXPECT_EQ(std::vector<std::string>({"./sipp", "-sn", "uac", "127.0.0.1:5061", "-key", "role", "uac", "-key", "idx", "1"}), commands[3].argv);
+}
+
+TEST(MultiInstanceConfig, ReportsInvalidCsvRows)
+{
+    const std::string csv =
+        "role,count,args\n"
+        "uas,0,\"-sn uas\"\n";
+
+    std::string error;
+    std::vector<MultiInstanceSpec> specs;
+
+    EXPECT_FALSE(parse_multi_instance_csv(csv, "bad.csv", &specs, &error));
+    EXPECT_NE(std::string::npos, error.find("count must be greater than zero"));
 }


### PR DESCRIPTION
## Summary
- Add a `-multi` launcher mode that reads `role,count,args` CSV rows and starts multiple SIPp child processes.
- Add `-multi_base_port` plus `{role}`, `{instance}`, `{base_port}`, `{instance_port}`, and `{port}` placeholders for generated child arguments.
- Document the CSV format and add unit coverage for parsing, validation, and argument expansion.

## Validation
- `g++ -std=c++17 -Wall -Werror -pedantic -Iinclude -c src/multi_instance.cpp -o /tmp/multi_instance.o`
- Docker Debian build: `cmake --build /work/build --target sipp_unittest`, `/work/build/sipp_unittest`, `cmake --build /work/build --target sipp`
- Smoke: `./build/sipp -multi /tmp/sipp-multi-smoke.csv -multi_base_port 5070` with 2 UAS + 2 UAC `-m 0` children exited successfully.