### PR TITLE
Add multi-instance launcher

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Welcome to SIPp reference documentation!
    3PCC_extended
    controlling
    transport
+   multi_instance
    media
    statistics
    error

--- a/docs/multi_instance.rst
+++ b/docs/multi_instance.rst
@@ -1,0 +1,34 @@
+Multi-instance launcher
+=======================
+
+SIPp can launch several SIPp processes from one CSV configuration file.  This
+is useful when a test needs matching groups of UAC and UAS instances.
+
+Use ``-multi`` with a CSV file:
+
+.. code-block:: bash
+
+   ./sipp -multi multi.csv -multi_base_port 5060
+
+The CSV format is:
+
+.. code-block:: text
+
+   role,count,args
+   uas,2,"-sn uas -p {instance_port} -nostdin"
+   uac,2,"-sn uac 127.0.0.1:{instance_port} -m 100 -nostdin"
+
+Each row creates ``count`` child processes.  The ``args`` field is split like
+command-line arguments and passed to each child ``sipp`` process.
+
+The following placeholders are expanded in the ``args`` field:
+
+* ``{role}``: the role column value.
+* ``{instance}``: the zero-based instance number within that role.
+* ``{base_port}``: the value passed with ``-multi_base_port``.
+* ``{instance_port}``: ``base_port + instance``.  Use this to pair UAC and UAS
+  rows by instance number.
+* ``{port}``: a globally increasing port number for every child process.
+
+The launcher waits until all children exit and returns the first non-zero child
+exit code.  If all children exit successfully, the launcher exits with zero.

--- a/include/multi_instance.hpp
+++ b/include/multi_instance.hpp
@@ -1,0 +1,46 @@
+/*
+ * Multi-instance launcher support for SIPp.
+ */
+
+#ifndef __MULTI_INSTANCE__
+#define __MULTI_INSTANCE__
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+struct MultiInstanceSpec {
+    std::string role;
+    int count;
+    std::string args;
+};
+
+struct MultiInstanceCommand {
+    std::string role;
+    int instance;
+    int port;
+    std::string executable_path;
+    std::vector<std::string> argv;
+};
+
+std::string resolve_current_executable_path();
+
+bool parse_multi_instance_csv(const std::string &csv,
+                              const std::string &source_name,
+                              std::vector<MultiInstanceSpec> *specs,
+                              std::string *error);
+
+bool parse_multi_instance_csv_file(const std::string &path,
+                                   std::vector<MultiInstanceSpec> *specs,
+                                   std::string *error);
+
+std::vector<MultiInstanceCommand>
+build_multi_instance_commands(const std::string &program_path,
+                              const std::vector<MultiInstanceSpec> &specs,
+                              int base_port);
+
+int run_multi_instance_commands(const std::vector<MultiInstanceCommand> &commands,
+                                std::ostream &out,
+                                std::ostream &err);
+
+#endif

--- a/src/multi_instance.cpp
+++ b/src/multi_instance.cpp
@@ -1,0 +1,392 @@
+/*
+ * Multi-instance launcher support for SIPp.
+ */
+
+#include "multi_instance.hpp"
+
+#include <errno.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+static std::string trim_copy(const std::string &value)
+{
+    size_t first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return "";
+    }
+    size_t last = value.find_last_not_of(" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+static bool parse_csv_line(const std::string &line,
+                           std::vector<std::string> *fields,
+                           std::string *error)
+{
+    fields->clear();
+    std::string current;
+    bool in_quotes = false;
+
+    size_t i = 0;
+    while (i < line.size()) {
+        char ch = line[i];
+        if (in_quotes) {
+            if (ch == '"') {
+                if ((i + 1 < line.size()) && line[i + 1] == '"') {
+                    current.push_back('"');
+                    i += 2;
+                    continue;
+                } else {
+                    in_quotes = false;
+                }
+            } else {
+                current.push_back(ch);
+            }
+        } else if (ch == '"') {
+            in_quotes = true;
+        } else if (ch == ',') {
+            fields->push_back(trim_copy(current));
+            current.clear();
+        } else {
+            current.push_back(ch);
+        }
+        ++i;
+    }
+
+    if (in_quotes) {
+        *error = "unterminated quoted CSV field";
+        return false;
+    }
+
+    fields->push_back(trim_copy(current));
+    return true;
+}
+
+static bool split_args(const std::string &args,
+                       std::vector<std::string> *words,
+                       std::string *error)
+{
+    words->clear();
+    std::string current;
+    char quote = 0;
+    bool escaping = false;
+
+    for (char ch : args) {
+        if (escaping) {
+            current.push_back(ch);
+            escaping = false;
+            continue;
+        }
+        if (ch == '\\') {
+            escaping = true;
+            continue;
+        }
+        if (quote) {
+            if (ch == quote) {
+                quote = 0;
+            } else {
+                current.push_back(ch);
+            }
+            continue;
+        }
+        if (ch == '\'' || ch == '"') {
+            quote = ch;
+        } else if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n') {
+            if (!current.empty()) {
+                words->push_back(current);
+                current.clear();
+            }
+        } else {
+            current.push_back(ch);
+        }
+    }
+
+    if (escaping) {
+        current.push_back('\\');
+    }
+    if (quote) {
+        *error = "unterminated quoted argument";
+        return false;
+    }
+    if (!current.empty()) {
+        words->push_back(current);
+    }
+
+    return true;
+}
+
+static void replace_all(std::string *value,
+                        const std::string &needle,
+                        const std::string &replacement)
+{
+    size_t pos = 0;
+    while ((pos = value->find(needle, pos)) != std::string::npos) {
+        value->replace(pos, needle.size(), replacement);
+        pos += replacement.size();
+    }
+}
+
+static bool canonical_regular_file_path(const std::string &path,
+                                        std::string *canonical_path,
+                                        std::string *error)
+{
+    char resolved[PATH_MAX];
+    if (!realpath(path.c_str(), resolved)) {
+        *error = "unable to resolve multi-instance file: " + path + ": " +
+                 strerror(errno);
+        return false;
+    }
+
+    struct stat st;
+    if (stat(resolved, &st) != 0) {
+        *error = "unable to stat multi-instance file: " + std::string(resolved) +
+                 ": " + strerror(errno);
+        return false;
+    }
+    if (!S_ISREG(st.st_mode)) {
+        *error = "multi-instance file is not a regular file: " +
+                 std::string(resolved);
+        return false;
+    }
+
+    *canonical_path = resolved;
+    return true;
+}
+
+std::string resolve_current_executable_path()
+{
+#ifdef __linux__
+    char path[PATH_MAX];
+    ssize_t length = readlink("/proc/self/exe", path, sizeof(path) - 1);
+    if (length > 0) {
+        path[length] = '\0';
+        return path;
+    }
+#elif defined(__APPLE__)
+    char path[PATH_MAX];
+    uint32_t size = sizeof(path);
+    if (_NSGetExecutablePath(path, &size) == 0) {
+        char resolved[PATH_MAX];
+        if (realpath(path, resolved)) {
+            return resolved;
+        }
+        return path;
+    }
+#endif
+
+    return "sipp";
+}
+
+bool parse_multi_instance_csv(const std::string &csv,
+                              const std::string &source_name,
+                              std::vector<MultiInstanceSpec> *specs,
+                              std::string *error)
+{
+    specs->clear();
+    std::istringstream input(csv);
+    std::string line;
+    int line_number = 0;
+
+    while (std::getline(input, line)) {
+        ++line_number;
+        if (!line.empty() && line[line.size() - 1] == '\r') {
+            line.erase(line.size() - 1);
+        }
+        std::string trimmed = trim_copy(line);
+        if (trimmed.empty() || trimmed[0] == '#') {
+            continue;
+        }
+
+        std::vector<std::string> fields;
+        std::string parse_error;
+        if (!parse_csv_line(line, &fields, &parse_error)) {
+            *error = source_name + ":" + std::to_string(line_number) + ": " + parse_error;
+            return false;
+        }
+
+        if (fields.size() != 3) {
+            *error = source_name + ":" + std::to_string(line_number) +
+                     ": expected role,count,args";
+            return false;
+        }
+
+        if (line_number == 1 && fields[0] == "role" && fields[1] == "count" &&
+            fields[2] == "args") {
+            continue;
+        }
+
+        char *end = nullptr;
+        long count = strtol(fields[1].c_str(), &end, 10);
+        if (*end != '\0') {
+            *error = source_name + ":" + std::to_string(line_number) +
+                     ": count must be a number";
+            return false;
+        }
+        if (count <= 0) {
+            *error = source_name + ":" + std::to_string(line_number) +
+                     ": count must be greater than zero";
+            return false;
+        }
+        if (fields[0].empty()) {
+            *error = source_name + ":" + std::to_string(line_number) +
+                     ": role must not be empty";
+            return false;
+        }
+
+        std::vector<std::string> unused_words;
+        if (!split_args(fields[2], &unused_words, error)) {
+            *error = source_name + ":" + std::to_string(line_number) + ": " + *error;
+            return false;
+        }
+
+        MultiInstanceSpec spec;
+        spec.role = fields[0];
+        spec.count = static_cast<int>(count);
+        spec.args = fields[2];
+        specs->push_back(spec);
+    }
+
+    if (specs->empty()) {
+        *error = source_name + ": no multi-instance rows found";
+        return false;
+    }
+
+    return true;
+}
+
+bool parse_multi_instance_csv_file(const std::string &path,
+                                   std::vector<MultiInstanceSpec> *specs,
+                                   std::string *error)
+{
+    std::string canonical_path;
+    if (!canonical_regular_file_path(path, &canonical_path, error)) {
+        return false;
+    }
+
+    std::ifstream file(canonical_path);
+    if (!file.good()) {
+        *error = "unable to open multi-instance file: " + canonical_path;
+        return false;
+    }
+
+    std::ostringstream contents;
+    contents << file.rdbuf();
+    return parse_multi_instance_csv(contents.str(), canonical_path, specs, error);
+}
+
+std::vector<MultiInstanceCommand>
+build_multi_instance_commands(const std::string &program_path,
+                              const std::vector<MultiInstanceSpec> &specs,
+                              int base_port)
+{
+    std::vector<MultiInstanceCommand> commands;
+    int next_port = base_port;
+
+    for (const MultiInstanceSpec &spec : specs) {
+        for (int instance = 0; instance < spec.count; ++instance) {
+            std::string expanded = spec.args;
+            int instance_port = base_port + instance;
+            replace_all(&expanded, "{role}", spec.role);
+            replace_all(&expanded, "{instance}", std::to_string(instance));
+            replace_all(&expanded, "{instance_port}", std::to_string(instance_port));
+            replace_all(&expanded, "{base_port}", std::to_string(base_port));
+            replace_all(&expanded, "{port}", std::to_string(next_port));
+
+            std::vector<std::string> words;
+            std::string error;
+            if (!split_args(expanded, &words, &error)) {
+                words.clear();
+            }
+
+            MultiInstanceCommand command;
+            command.role = spec.role;
+            command.instance = instance;
+            command.port = next_port;
+            command.executable_path = program_path;
+            command.argv.push_back(program_path);
+            command.argv.insert(command.argv.end(), words.begin(), words.end());
+            commands.push_back(command);
+            ++next_port;
+        }
+    }
+
+    return commands;
+}
+
+int run_multi_instance_commands(const std::vector<MultiInstanceCommand> &commands,
+                                std::ostream &out,
+                                std::ostream &err)
+{
+    std::vector<pid_t> children;
+    int exit_code = 0;
+
+    for (const MultiInstanceCommand &command : commands) {
+        out << "Starting " << command.role << "[" << command.instance << "]";
+        if (command.port > 0) {
+            out << " port=" << command.port;
+        }
+        out << ":";
+        for (const std::string &arg : command.argv) {
+            out << " " << arg;
+        }
+        out << "\n";
+        out.flush();
+
+        pid_t child = fork();
+        if (child < 0) {
+            err << "fork failed: " << strerror(errno) << "\n";
+            exit_code = 1;
+            break;
+        }
+        if (child == 0) {
+            std::vector<char *> argv;
+            argv.reserve(command.argv.size() + 1);
+            for (const std::string &arg : command.argv) {
+                argv.push_back(const_cast<char *>(arg.c_str()));
+            }
+            argv.push_back(nullptr);
+            execv(command.executable_path.c_str(), argv.data());
+            std::cerr << "exec failed for " << command.executable_path << ": "
+                      << strerror(errno) << "\n";
+            _exit(127);
+        }
+        children.push_back(child);
+    }
+
+    for (pid_t child : children) {
+        int status = 0;
+        while (waitpid(child, &status, 0) < 0) {
+            if (errno != EINTR) {
+                err << "waitpid failed for " << child << ": " << strerror(errno) << "\n";
+                exit_code = 1;
+                break;
+            }
+        }
+        if (WIFEXITED(status)) {
+            int child_exit = WEXITSTATUS(status);
+            if (child_exit != 0 && exit_code == 0) {
+                exit_code = child_exit;
+            }
+        } else if (WIFSIGNALED(status)) {
+            int signal_number = WTERMSIG(status);
+            if (exit_code == 0) {
+                exit_code = 128 + signal_number;
+            }
+        }
+    }
+
+    return exit_code;
+}

--- a/src/sipp.cpp
+++ b/src/sipp.cpp
@@ -58,6 +58,7 @@ extern char** environ;
 #define GLOBALS_FULL_DEFINITION
 #include "sipp.hpp"
 
+#include "multi_instance.hpp"
 #include "sip_parser.hpp"
 #include "socket.hpp"
 #include "logger.hpp"
@@ -124,6 +125,8 @@ struct sipp_option {
 #define SIPP_OPTION_NEED_SCTP     39
 #define SIPP_OPTION_RX_SCENARIO   40
 #define SIPP_OPTION_RX_INPUT_FILE 41
+#define SIPP_OPTION_CID_TYPE      42
+#define SIPP_OPTION_MULTI         43
 #define SIPP_HELP_TEXT_HEADER    255
 
 static char *call_id_mode_string = nullptr;
@@ -259,6 +262,10 @@ struct sipp_option options_table[] = {
    {"buff_size", "Set the send and receive buffer size.", SIPP_OPTION_INT, &buff_size, 1},
    {"sendbuffer_warn", "Produce warnings instead of errors on SendBuffer failures.", SIPP_OPTION_BOOL, &sendbuffer_warn, 1},
    {"lost", "Set the number of packets to lose by default (scenario specifications override this value).", SIPP_OPTION_FLOAT, &global_lost, 1},
+   {"multi", "Launch multiple SIPp instances from a CSV file and wait for all of them to exit.\n"
+    "CSV format: role,count,args. The args field is split like shell arguments and supports {role}, {instance}, {base_port}, {instance_port}, and {port} placeholders.\n"
+    "Example row: uas,2,\"-sn uas -p {port}\"", SIPP_OPTION_MULTI, nullptr, 0},
+   {"multi_base_port", "Set the first {port} value used by -multi. Default is 5060.", SIPP_OPTION_MULTI, nullptr, 0},
    {"key", "keyword value\nSet the generic parameter named \"keyword\" to \"value\".", SIPP_OPTION_KEY, nullptr, 1},
    {"set", "variable value\nSet the global variable parameter named \"variable\" to \"value\".", SIPP_OPTION_VAR, nullptr, 3},
    {"tdmmap", "Generate and handle a table of TDM circuits.\n"
@@ -1393,6 +1400,67 @@ void randomseed(void)
     srand(seed);
 }
 
+static bool get_multi_arg(int argc,
+                          char *argv[],
+                          int *argi,
+                          const char *option,
+                          std::string *value)
+{
+    if ((*argi + 1) >= argc) {
+        std::cerr << "Missing argument for " << option << "\n";
+        return false;
+    }
+    ++(*argi);
+    *value = argv[*argi];
+    return true;
+}
+
+static bool maybe_run_multi_instance(int argc, char *argv[], int *exit_code)
+{
+    std::string config_path;
+    int base_port = DEFAULT_PORT;
+
+    for (int argi = 1; argi < argc; ++argi) {
+        if (!strcmp(argv[argi], "-multi")) {
+            if (!get_multi_arg(argc, argv, &argi, "-multi", &config_path)) {
+                *exit_code = EXIT_OTHER;
+                return true;
+            }
+        } else if (!strcmp(argv[argi], "-multi_base_port")) {
+            std::string value;
+            if (!get_multi_arg(argc, argv, &argi, "-multi_base_port", &value)) {
+                *exit_code = EXIT_OTHER;
+                return true;
+            }
+            char *end = nullptr;
+            long parsed_port = strtol(value.c_str(), &end, 10);
+            if (*end != '\0' || parsed_port <= 0 || parsed_port > 65535) {
+                std::cerr << "Invalid -multi_base_port value: " << value << "\n";
+                *exit_code = EXIT_OTHER;
+                return true;
+            }
+            base_port = static_cast<int>(parsed_port);
+        }
+    }
+
+    if (config_path.empty()) {
+        return false;
+    }
+
+    std::vector<MultiInstanceSpec> specs;
+    std::string error;
+    if (!parse_multi_instance_csv_file(config_path, &specs, &error)) {
+        std::cerr << error << "\n";
+        *exit_code = EXIT_OTHER;
+        return true;
+    }
+
+    std::vector<MultiInstanceCommand> commands =
+        build_multi_instance_commands(resolve_current_executable_path(), specs, base_port);
+    *exit_code = run_multi_instance_commands(commands, std::cout, std::cerr);
+    return true;
+}
+
 /* Main */
 int main(int argc, char *argv[])
 {
@@ -1406,6 +1474,11 @@ int main(int argc, char *argv[])
     echo_errors = 0;
 
     randomseed();
+
+    int multi_exit_code = 0;
+    if (maybe_run_multi_instance(argc, argv, &multi_exit_code)) {
+        return multi_exit_code;
+    }
 
     /* At least one argument is needed */
     if (argc < 2) {

--- a/src/sipp_unittest.cpp
+++ b/src/sipp_unittest.cpp
@@ -19,6 +19,8 @@
 #define GLOBALS_FULL_DEFINITION
 #include "sipp.hpp"
 
+#include "multi_instance.hpp"
+
 #include "gtest/gtest.h"
 #include <string.h>
 
@@ -38,4 +40,45 @@ int main(int argc, char* argv[])
 void sipp_exit(int rc, int rtp_errors, int echo_errors)
 {
     exit(rc);
+}
+
+TEST(MultiInstanceConfig, ParsesQuotedCsvAndExpandsInstanceArguments)
+{
+    const std::string csv =
+        "role,count,args\n"
+        "uas,2,\"-sn uas -p {port}\"\n"
+        "uac,2,\"-sn uac 127.0.0.1:{instance_port} -key role {role} -key idx {instance}\"\n";
+
+    std::string error;
+    std::vector<MultiInstanceSpec> specs;
+
+    ASSERT_TRUE(parse_multi_instance_csv(csv, "inline.csv", &specs, &error)) << error;
+    ASSERT_EQ(2u, specs.size());
+    EXPECT_EQ("uas", specs[0].role);
+    EXPECT_EQ(2, specs[0].count);
+    EXPECT_EQ("-sn uas -p {port}", specs[0].args);
+    EXPECT_EQ("uac", specs[1].role);
+    EXPECT_EQ(2, specs[1].count);
+
+    std::vector<MultiInstanceCommand> commands =
+        build_multi_instance_commands("./sipp", specs, 5060);
+
+    ASSERT_EQ(4u, commands.size());
+    EXPECT_EQ(std::vector<std::string>({"./sipp", "-sn", "uas", "-p", "5060"}), commands[0].argv);
+    EXPECT_EQ(std::vector<std::string>({"./sipp", "-sn", "uas", "-p", "5061"}), commands[1].argv);
+    EXPECT_EQ(std::vector<std::string>({"./sipp", "-sn", "uac", "127.0.0.1:5060", "-key", "role", "uac", "-key", "idx", "0"}), commands[2].argv);
+    EXPECT_EQ(std::vector<std::string>({"./sipp", "-sn", "uac", "127.0.0.1:5061", "-key", "role", "uac", "-key", "idx", "1"}), commands[3].argv);
+}
+
+TEST(MultiInstanceConfig, ReportsInvalidCsvRows)
+{
+    const std::string csv =
+        "role,count,args\n"
+        "uas,0,\"-sn uas\"\n";
+
+    std::string error;
+    std::vector<MultiInstanceSpec> specs;
+
+    EXPECT_FALSE(parse_multi_instance_csv(csv, "bad.csv", &specs, &error));
+    EXPECT_NE(std::string::npos, error.find("count must be greater than zero"));
 }


### PR DESCRIPTION
## Summary
- Add a `-multi` launcher mode that reads `role,count,args` CSV rows and starts multiple SIPp child processes.
- Add `-multi_base_port` plus `{role}`, `{instance}`, `{base_port}`, `{instance_port}`, and `{port}` placeholders for generated child arguments.
- Document the CSV format and add unit coverage for parsing, validation, and argument expansion.
- Resolve CodeQL findings by canonicalizing the CSV file path, requiring a regular file, avoiding `execvp`, and using the current executable path for child launches.

## Validation
- Local compile check: `g++ -std=c++17 -Wall -Werror -pedantic -Iinclude -c src/multi_instance.cpp -o /tmp/multi_instance.o`
- Local Docker Debian build from a fresh build directory: `cmake -S /work -B /work/build-upstream -DUSE_GSL=0 -DUSE_SCTP=0 -DUSE_PCAP=0`
- Local unit tests: `/work/build-upstream/sipp_unittest` (`61 passed`)
- Local binary build: `cmake --build /work/build-upstream --target sipp`
- Local smoke: `./build-upstream/sipp -multi /tmp/sipp-multi-upstream-smoke.csv -multi_base_port 5070` with 2 UAS + 2 UAC `-m 0` children exited successfully.
- GitHub checks passing: lint, build, build-system-gtest, build-osx, build-static, build-wolfssl, codespell, CodeQL Analyze, and CodeQL alerts.